### PR TITLE
Convert some components to Vue composition API

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,7 +54,7 @@ export default [
                 { selector: "default", format: ["camelCase"] },
                 { selector: "enumMember", format: ["UPPER_CASE"] },
                 { selector: "import", format: ["camelCase", "PascalCase"] },
-                { selector: "objectLiteralProperty", format: ["camelCase", "UPPER_CASE"], leadingUnderscore: "forbid" },
+                { selector: "objectLiteralProperty", format: ["camelCase", "PascalCase", "UPPER_CASE"], leadingUnderscore: "forbid" },
                 { selector: "typeParameter", format: ["PascalCase"] },
                 { selector: "variable", modifiers: ["const"], format: ["camelCase", "UPPER_CASE"] },
             ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,13 @@
         "vuex": "4.1.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "6.8.0",
         "@testing-library/user-event": "14.6.1",
         "@testing-library/vue": "8.1.0",
         "@typescript-eslint/parser": "8.40.0",
         "@vitejs/plugin-vue": "6.0.1",
         "@vitest/coverage-v8": "3.2.4",
+        "canvas": "3.2.0",
         "coveralls": "3.1.1",
         "eslint": "9.34.0",
         "jsdom": "26.1.0",
@@ -37,11 +39,19 @@
         "vue-eslint-parser": "10.2.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -64,13 +74,6 @@
         "lru-cache": "^10.4.3"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -85,13 +88,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/code-frame/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -282,9 +278,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.7.tgz",
-      "integrity": "sha512-uD0kKFHh6ETr8TqEtaAcV+dn/2qnYbH/+8wGEdY70Qf7l1l/jmBUbrmQqwiPKAQE6cOQ7dTj6Xr0HzQDGHyceQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
       "cpu": [
         "ppc64"
       ],
@@ -299,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.7.tgz",
-      "integrity": "sha512-Jhuet0g1k9rAJHrXGIh7sFknFuT4sfytYZpZpuZl7YKDhnPByVAm5oy2LEBmMbuYf3ejWVYCc2seX81Mk+madA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
       "cpu": [
         "arm"
       ],
@@ -316,9 +312,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.7.tgz",
-      "integrity": "sha512-p0ohDnwyIbAtztHTNUTzN5EGD/HJLs1bwysrOPgSdlIA6NDnReoVfoCyxG6W1d85jr2X80Uq5KHftyYgaK9LPQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.7.tgz",
-      "integrity": "sha512-mMxIJFlSgVK23HSsII3ZX9T2xKrBCDGyk0qiZnIW10LLFFtZLkFD6imZHu7gUo2wkNZwS9Yj3mOtZD3ZPcjCcw==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
       "cpu": [
         "x64"
       ],
@@ -350,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.7.tgz",
-      "integrity": "sha512-jyOFLGP2WwRwxM8F1VpP6gcdIJc8jq2CUrURbbTouJoRO7XCkU8GdnTDFIHdcifVBT45cJlOYsZ1kSlfbKjYUQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.7.tgz",
-      "integrity": "sha512-m9bVWqZCwQ1BthruifvG64hG03zzz9gE2r/vYAhztBna1/+qXiHyP9WgnyZqHgGeXoimJPhAmxfbeU+nMng6ZA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
       "cpu": [
         "x64"
       ],
@@ -384,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.7.tgz",
-      "integrity": "sha512-Bss7P4r6uhr3kDzRjPNEnTm/oIBdTPRNQuwaEFWT/uvt6A1YzK/yn5kcx5ZxZ9swOga7LqeYlu7bDIpDoS01bA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
       "cpu": [
         "arm64"
       ],
@@ -401,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.7.tgz",
-      "integrity": "sha512-S3BFyjW81LXG7Vqmr37ddbThrm3A84yE7ey/ERBlK9dIiaWgrjRlre3pbG7txh1Uaxz8N7wGGQXmC9zV+LIpBQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
       "cpu": [
         "x64"
       ],
@@ -418,9 +414,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.7.tgz",
-      "integrity": "sha512-JZMIci/1m5vfQuhKoFXogCKVYVfYQmoZJg8vSIMR4TUXbF+0aNlfXH3DGFEFMElT8hOTUF5hisdZhnrZO/bkDw==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
       "cpu": [
         "arm"
       ],
@@ -435,9 +431,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.7.tgz",
-      "integrity": "sha512-HfQZQqrNOfS1Okn7PcsGUqHymL1cWGBslf78dGvtrj8q7cN3FkapFgNA4l/a5lXDwr7BqP2BSO6mz9UremNPbg==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
       "cpu": [
         "arm64"
       ],
@@ -452,9 +448,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.7.tgz",
-      "integrity": "sha512-9Jex4uVpdeofiDxnwHRgen+j6398JlX4/6SCbbEFEXN7oMO2p0ueLN+e+9DdsdPLUdqns607HmzEFnxwr7+5wQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
       "cpu": [
         "ia32"
       ],
@@ -469,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.7.tgz",
-      "integrity": "sha512-TG1KJqjBlN9IHQjKVUYDB0/mUGgokfhhatlay8aZ/MSORMubEvj/J1CL8YGY4EBcln4z7rKFbsH+HeAv0d471w==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
       "cpu": [
         "loong64"
       ],
@@ -486,9 +482,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.7.tgz",
-      "integrity": "sha512-Ty9Hj/lx7ikTnhOfaP7ipEm/ICcBv94i/6/WDg0OZ3BPBHhChsUbQancoWYSO0WNkEiSW5Do4febTTy4x1qYQQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
       "cpu": [
         "mips64el"
       ],
@@ -503,9 +499,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.7.tgz",
-      "integrity": "sha512-MrOjirGQWGReJl3BNQ58BLhUBPpWABnKrnq8Q/vZWWwAB1wuLXOIxS2JQ1LT3+5T+3jfPh0tyf5CpbyQHqnWIQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
       "cpu": [
         "ppc64"
       ],
@@ -520,9 +516,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.7.tgz",
-      "integrity": "sha512-9pr23/pqzyqIZEZmQXnFyqp3vpa+KBk5TotfkzGMqpw089PGm0AIowkUppHB9derQzqniGn3wVXgck19+oqiOw==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
       "cpu": [
         "riscv64"
       ],
@@ -537,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.7.tgz",
-      "integrity": "sha512-4dP11UVGh9O6Y47m8YvW8eoA3r8qL2toVZUbBKyGta8j6zdw1cn9F/Rt59/Mhv0OgY68pHIMjGXWOUaykCnx+w==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
       "cpu": [
         "s390x"
       ],
@@ -554,9 +550,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.7.tgz",
-      "integrity": "sha512-ghJMAJTdw/0uhz7e7YnpdX1xVn7VqA0GrWrAO2qKMuqbvgHT2VZiBv1BQ//VcHsPir4wsL3P2oPggfKPzTKoCA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
       "cpu": [
         "x64"
       ],
@@ -571,9 +567,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.7.tgz",
-      "integrity": "sha512-bwXGEU4ua45+u5Ci/a55B85KWaDSRS8NPOHtxy2e3etDjbz23wlry37Ffzapz69JAGGc4089TBo+dGzydQmydg==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
       "cpu": [
         "arm64"
       ],
@@ -588,9 +584,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.7.tgz",
-      "integrity": "sha512-tUZRvLtgLE5OyN46sPSYlgmHoBS5bx2URSrgZdW1L1teWPYVmXh+QN/sKDqkzBo/IHGcKcHLKDhBeVVkO7teEA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
       "cpu": [
         "x64"
       ],
@@ -605,9 +601,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.7.tgz",
-      "integrity": "sha512-bTJ50aoC+WDlDGBReWYiObpYvQfMjBNlKztqoNUL0iUkYtwLkBQQeEsTq/I1KyjsKA5tyov6VZaPb8UdD6ci6Q==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
       "cpu": [
         "arm64"
       ],
@@ -622,9 +618,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.7.tgz",
-      "integrity": "sha512-TA9XfJrgzAipFUU895jd9j2SyDh9bbNkK2I0gHcvqb/o84UeQkBpi/XmYX3cO1q/9hZokdcDqQxIi6uLVrikxg==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
       "cpu": [
         "x64"
       ],
@@ -639,9 +635,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.7.tgz",
-      "integrity": "sha512-5VTtExUrWwHHEUZ/N+rPlHDwVFQ5aME7vRJES8+iQ0xC/bMYckfJ0l2n3yGIfRoXcK/wq4oXSItZAz5wslTKGw==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +652,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.7.tgz",
-      "integrity": "sha512-umkbn7KTxsexhv2vuuJmj9kggd4AEtL32KodkJgfhNOHMPtQ55RexsaSrMb+0+jp9XL4I4o2y91PZauVN4cH3A==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
       "cpu": [
         "x64"
       ],
@@ -673,9 +669,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.7.tgz",
-      "integrity": "sha512-j20JQGP/gz8QDgzl5No5Gr4F6hurAZvtkFxAKhiv2X49yi/ih8ECK4Y35YnjlMogSKJk931iNMcd35BtZ4ghfw==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
       "cpu": [
         "arm64"
       ],
@@ -690,9 +686,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.7.tgz",
-      "integrity": "sha512-4qZ6NUfoiiKZfLAXRsvFkA0hoWVM+1y2bSHXHkpdLAs/+r0LgwqYohmfZCi985c6JWHhiXP30mgZawn/XrqAkQ==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
       "cpu": [
         "ia32"
       ],
@@ -707,9 +703,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.7.tgz",
-      "integrity": "sha512-FaPsAHTwm+1Gfvn37Eg3E5HIpfR3i6x1AIcla/MkqAIupD4BW3MrSeUqfoTzwwJhk3WE2/KqUn4/eenEJC76VA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
       "cpu": [
         "x64"
       ],
@@ -742,11 +738,25 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -855,16 +865,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -947,6 +947,7 @@
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -956,6 +957,7 @@
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
@@ -969,6 +971,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -982,6 +985,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -1004,11 +1008,35 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1026,22 +1054,20 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1049,29 +1075,23 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1080,7 +1100,8 @@
     "node_modules/@mdi/font": {
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
-      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw=="
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1442,6 +1463,7 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -1455,9 +1477,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.0.tgz",
+      "integrity": "sha512-aVzKH922ogVAWkKiyKXorjYymz2084zrhrZRXtLrA5eEx5SO8Dj0c/4FpCHZyn7MKzhW2pW4tK28vVr+5oQ2xw==",
       "cpu": [
         "arm"
       ],
@@ -1469,9 +1491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.0.tgz",
+      "integrity": "sha512-diOdQuw43xTa1RddAFbhIA8toirSzFMcnIg8kvlzRbK26xqEnKJ/vqQnghTAajy2Dcy42v+GMPMo6jq67od+Dw==",
       "cpu": [
         "arm64"
       ],
@@ -1483,9 +1505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.0.tgz",
+      "integrity": "sha512-QhR2KA18fPlJWFefySJPDYZELaVqIUVnYgAOdtJ+B/uH96CFg2l1TQpX19XpUMWUqMyIiyY45wje8K6F4w4/CA==",
       "cpu": [
         "arm64"
       ],
@@ -1497,9 +1519,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.0.tgz",
+      "integrity": "sha512-Q9RMXnQVJ5S1SYpNSTwXDpoQLgJ/fbInWOyjbCnnqTElEyeNvLAB3QvG5xmMQMhFN74bB5ZZJYkKaFPcOG8sGg==",
       "cpu": [
         "x64"
       ],
@@ -1511,9 +1533,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.0.tgz",
+      "integrity": "sha512-3jzOhHWM8O8PSfyft+ghXZfBkZawQA0PUGtadKYxFqpcYlOYjTi06WsnYBsbMHLawr+4uWirLlbhcYLHDXR16w==",
       "cpu": [
         "arm64"
       ],
@@ -1525,9 +1547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.0.tgz",
+      "integrity": "sha512-NcD5uVUmE73C/TPJqf78hInZmiSBsDpz3iD5MF/BuB+qzm4ooF2S1HfeTChj5K4AV3y19FFPgxonsxiEpy8v/A==",
       "cpu": [
         "x64"
       ],
@@ -1539,9 +1561,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.0.tgz",
+      "integrity": "sha512-JWnrj8qZgLWRNHr7NbpdnrQ8kcg09EBBq8jVOjmtlB3c8C6IrynAJSMhMVGME4YfTJzIkJqvSUSVJRqkDnu/aA==",
       "cpu": [
         "arm"
       ],
@@ -1553,9 +1575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.0.tgz",
+      "integrity": "sha512-9xu92F0TxuMH0tD6tG3+GtngwdgSf8Bnz+YcsPG91/r5Vgh5LNofO48jV55priA95p3c92FLmPM7CvsVlnSbGQ==",
       "cpu": [
         "arm"
       ],
@@ -1567,9 +1589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.0.tgz",
+      "integrity": "sha512-NLtvJB5YpWn7jlp1rJiY0s+G1Z1IVmkDuiywiqUhh96MIraC0n7XQc2SZ1CZz14shqkM+XN2UrfIo7JB6UufOA==",
       "cpu": [
         "arm64"
       ],
@@ -1581,9 +1603,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.0.tgz",
+      "integrity": "sha512-QJ4hCOnz2SXgCh+HmpvZkM+0NSGcZACyYS8DGbWn2PbmA0e5xUk4bIP8eqJyNXLtyB4gZ3/XyvKtQ1IFH671vQ==",
       "cpu": [
         "arm64"
       ],
@@ -1595,9 +1617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.0.tgz",
+      "integrity": "sha512-Pk0qlGJnhILdIC5zSKQnprFjrGmjfDM7TPZ0FKJxRkoo+kgMRAg4ps1VlTZf8u2vohSicLg7NP+cA5qE96PaFg==",
       "cpu": [
         "loong64"
       ],
@@ -1608,10 +1630,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.0.tgz",
+      "integrity": "sha512-/dNFc6rTpoOzgp5GKoYjT6uLo8okR/Chi2ECOmCZiS4oqh3mc95pThWma7Bgyk6/WTEvjDINpiBCuecPLOgBLQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1623,9 +1645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.0.tgz",
+      "integrity": "sha512-YBwXsvsFI8CVA4ej+bJF2d9uAeIiSkqKSPQNn0Wyh4eMDY4wxuSp71BauPjQNCKK2tD2/ksJ7uhJ8X/PVY9bHQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1637,9 +1659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.0.tgz",
+      "integrity": "sha512-FI3Rr2aGAtl1aHzbkBIamsQyuauYtTF9SDUJ8n2wMXuuxwchC3QkumZa1TEXYIv/1AUp1a25Kwy6ONArvnyeVQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1651,9 +1673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.0.tgz",
+      "integrity": "sha512-Dx7qH0/rvNNFmCcIRe1pyQ9/H0XO4v/f0SDoafwRYwc2J7bJZ5N4CHL/cdjamISZ5Cgnon6iazAVRFlxSoHQnQ==",
       "cpu": [
         "s390x"
       ],
@@ -1665,9 +1687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.0.tgz",
+      "integrity": "sha512-GUdZKTeKBq9WmEBzvFYuC88yk26vT66lQV8D5+9TgkfbewhLaTHRNATyzpQwwbHIfJvDJ3N9WJ90wK/uR3cy3Q==",
       "cpu": [
         "x64"
       ],
@@ -1679,9 +1701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.0.tgz",
+      "integrity": "sha512-ao58Adz/v14MWpQgYAb4a4h3fdw73DrDGtaiF7Opds5wNyEQwtO6M9dBh89nke0yoZzzaegq6J/EXs7eBebG8A==",
       "cpu": [
         "x64"
       ],
@@ -1693,9 +1715,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.0.tgz",
+      "integrity": "sha512-kpFno46bHtjZVdRIOxqaGeiABiToo2J+st7Yce+aiAoo1H0xPi2keyQIP04n2JjDVuxBN6bSz9R6RdTK5hIppw==",
       "cpu": [
         "arm64"
       ],
@@ -1707,9 +1729,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.0.tgz",
+      "integrity": "sha512-rFYrk4lLk9YUTIeihnQMiwMr6gDhGGSbWThPEDfBoU/HdAtOzPXeexKi7yU8jO+LWRKnmqPN9NviHQf6GDwBcQ==",
       "cpu": [
         "ia32"
       ],
@@ -1721,9 +1743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.0.tgz",
+      "integrity": "sha512-sq0hHLTgdtwOPDB5SJOuaoHyiP1qSwg+71TQWk8iDS04bW1wIE0oQ6otPiRj2ZvLYNASLMaTp8QRGUVZ+5OL5A==",
       "cpu": [
         "x64"
       ],
@@ -1803,6 +1825,33 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
@@ -1955,6 +2004,16 @@
         "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2149,19 +2208,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
@@ -2341,6 +2387,18 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2393,7 +2451,8 @@
     "node_modules/@vue/devtools-api": {
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.19",
@@ -2518,6 +2577,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2530,15 +2590,13 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2546,6 +2604,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2561,6 +2620,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -2571,7 +2631,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2598,6 +2657,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -2607,6 +2667,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2622,22 +2683,30 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
-      "integrity": "sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.4.tgz",
+      "integrity": "sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.29",
         "estree-walker": "^3.0.3",
         "js-tokens": "^9.0.1"
       }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2660,6 +2729,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -2668,28 +2738,65 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2705,6 +2812,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-builder": {
@@ -2784,16 +2916,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chai": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
-      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2812,6 +2960,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2850,11 +2999,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2866,7 +3023,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colorjs.io": {
       "version": "0.5.2",
@@ -2880,6 +3038,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2901,7 +3060,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -2918,13 +3078,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/coveralls": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
       "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
@@ -2954,6 +3116,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -2979,6 +3148,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -3004,6 +3174,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
       "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3035,6 +3206,22 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3079,11 +3266,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3126,6 +3324,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3136,7 +3335,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3181,13 +3379,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -3232,12 +3432,25 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -3307,9 +3520,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.7.tgz",
-      "integrity": "sha512-daJB0q2dmTzo90L9NjRaohhRWrCzYxWNFTjEi72/h+p5DcY3yn4MacWfDakHmaBaDzDiuLJsCh0+6LK/iX+c+Q==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3320,32 +3533,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.7",
-        "@esbuild/android-arm": "0.25.7",
-        "@esbuild/android-arm64": "0.25.7",
-        "@esbuild/android-x64": "0.25.7",
-        "@esbuild/darwin-arm64": "0.25.7",
-        "@esbuild/darwin-x64": "0.25.7",
-        "@esbuild/freebsd-arm64": "0.25.7",
-        "@esbuild/freebsd-x64": "0.25.7",
-        "@esbuild/linux-arm": "0.25.7",
-        "@esbuild/linux-arm64": "0.25.7",
-        "@esbuild/linux-ia32": "0.25.7",
-        "@esbuild/linux-loong64": "0.25.7",
-        "@esbuild/linux-mips64el": "0.25.7",
-        "@esbuild/linux-ppc64": "0.25.7",
-        "@esbuild/linux-riscv64": "0.25.7",
-        "@esbuild/linux-s390x": "0.25.7",
-        "@esbuild/linux-x64": "0.25.7",
-        "@esbuild/netbsd-arm64": "0.25.7",
-        "@esbuild/netbsd-x64": "0.25.7",
-        "@esbuild/openbsd-arm64": "0.25.7",
-        "@esbuild/openbsd-x64": "0.25.7",
-        "@esbuild/openharmony-arm64": "0.25.7",
-        "@esbuild/sunos-x64": "0.25.7",
-        "@esbuild/win32-arm64": "0.25.7",
-        "@esbuild/win32-ia32": "0.25.7",
-        "@esbuild/win32-x64": "0.25.7"
+        "@esbuild/aix-ppc64": "0.25.9",
+        "@esbuild/android-arm": "0.25.9",
+        "@esbuild/android-arm64": "0.25.9",
+        "@esbuild/android-x64": "0.25.9",
+        "@esbuild/darwin-arm64": "0.25.9",
+        "@esbuild/darwin-x64": "0.25.9",
+        "@esbuild/freebsd-arm64": "0.25.9",
+        "@esbuild/freebsd-x64": "0.25.9",
+        "@esbuild/linux-arm": "0.25.9",
+        "@esbuild/linux-arm64": "0.25.9",
+        "@esbuild/linux-ia32": "0.25.9",
+        "@esbuild/linux-loong64": "0.25.9",
+        "@esbuild/linux-mips64el": "0.25.9",
+        "@esbuild/linux-ppc64": "0.25.9",
+        "@esbuild/linux-riscv64": "0.25.9",
+        "@esbuild/linux-s390x": "0.25.9",
+        "@esbuild/linux-x64": "0.25.9",
+        "@esbuild/netbsd-arm64": "0.25.9",
+        "@esbuild/netbsd-x64": "0.25.9",
+        "@esbuild/openbsd-arm64": "0.25.9",
+        "@esbuild/openbsd-x64": "0.25.9",
+        "@esbuild/openharmony-arm64": "0.25.9",
+        "@esbuild/sunos-x64": "0.25.9",
+        "@esbuild/win32-arm64": "0.25.9",
+        "@esbuild/win32-ia32": "0.25.9",
+        "@esbuild/win32-x64": "0.25.9"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3353,6 +3566,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3439,28 +3653,6 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
@@ -3473,14 +3665,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 4"
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -3488,6 +3681,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3513,24 +3707,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3544,6 +3726,7 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -3569,6 +3752,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -3588,8 +3772,19 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -3606,7 +3801,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -3615,13 +3811,15 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3657,13 +3855,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3680,6 +3880,7 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -3705,6 +3906,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -3721,6 +3923,7 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -3730,10 +3933,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3752,12 +3956,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -3772,6 +3977,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -3781,6 +3987,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3789,6 +3996,13 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3869,28 +4083,34 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3901,26 +4121,12 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3953,18 +4159,21 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gtp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gtp/-/gtp-3.0.1.tgz",
-      "integrity": "sha512-f34Rid892euEfDYGZphIT4i4pNijNuTETWtNpdOKidKE8lCAgqxXxMgzQEZACZhru8snRqBd24mX8XzOb3ttyQ=="
+      "integrity": "sha512-f34Rid892euEfDYGZphIT4i4pNijNuTETWtNpdOKidKE8lCAgqxXxMgzQEZACZhru8snRqBd24mX8XzOb3ttyQ==",
+      "license": "MIT"
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
@@ -3975,6 +4184,7 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -4001,6 +4211,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4077,7 +4288,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4098,6 +4310,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -4135,10 +4348,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4174,9 +4408,27 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4303,6 +4555,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4312,6 +4565,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4321,6 +4575,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -4462,7 +4717,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -4505,19 +4761,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
@@ -4527,6 +4786,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -4541,6 +4801,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
       "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
@@ -4551,10 +4812,11 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -4564,18 +4826,19 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
-      "engines": {
-        "node": "20 || >=22"
-      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-beautify": {
@@ -4600,67 +4863,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/js-beautify/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/js-beautify/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/js-beautify/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-beautify/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/js-cookie": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
@@ -4672,9 +4874,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4683,6 +4885,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4695,7 +4898,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -4737,59 +4941,53 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/jshighlight": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/jshighlight/-/jshighlight-0.3.3.tgz",
-      "integrity": "sha512-NaMtNpbMiRuDXsQvdSnFT+KIAND/Ri/135+7WIokRuBpC5ImrEIZpXWwzJ5wxrcodpnpwHtugyzI2c4mRPQITQ=="
+      "integrity": "sha512-NaMtNpbMiRuDXsQvdSnFT+KIAND/Ri/135+7WIokRuBpC5ImrEIZpXWwzJ5wxrcodpnpwHtugyzI2c4mRPQITQ==",
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4805,6 +5003,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -4814,6 +5013,7 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "bin": {
         "lcov-parse": "bin/cli.js"
       }
@@ -4823,6 +5023,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -4836,6 +5037,7 @@
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -4845,6 +5047,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -4859,38 +5062,39 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=0.8.6"
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
-      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "license": "ISC"
     },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -4903,12 +5107,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
@@ -4916,6 +5120,7 @@
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -4927,6 +5132,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -4942,6 +5148,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -4958,7 +5165,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4974,7 +5195,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5005,6 +5227,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5014,6 +5237,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5021,11 +5245,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5041,6 +5289,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5050,15 +5299,24 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5078,19 +5336,39 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -5120,6 +5398,7 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -5185,11 +5464,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -5207,6 +5497,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -5222,6 +5513,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -5236,7 +5528,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5264,24 +5557,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5291,21 +5572,23 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5332,7 +5615,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5391,11 +5675,49 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -5413,16 +5735,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -5446,16 +5758,35 @@
       "license": "ISC"
     },
     "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5465,6 +5796,7 @@
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5474,6 +5806,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
@@ -5499,12 +5832,53 @@
       ],
       "license": "MIT"
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -5519,6 +5893,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -5548,6 +5936,7 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5574,12 +5963,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/request/node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -5610,6 +6014,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
       "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^11.0.0",
         "package-json-from-dist": "^1.0.0"
@@ -5624,10 +6029,93 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.0.tgz",
+      "integrity": "sha512-BXHRqK1vyt9XVSEHZ9y7xdYtuYbwVod2mLwOMFP7t/Eqoc1pHRlG/WdV2qNeNvZHRQdLedaFycljaYYM96RqJQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5641,26 +6129,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.48.0",
+        "@rollup/rollup-android-arm64": "4.48.0",
+        "@rollup/rollup-darwin-arm64": "4.48.0",
+        "@rollup/rollup-darwin-x64": "4.48.0",
+        "@rollup/rollup-freebsd-arm64": "4.48.0",
+        "@rollup/rollup-freebsd-x64": "4.48.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.48.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.48.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.48.0",
+        "@rollup/rollup-linux-arm64-musl": "4.48.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.48.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.48.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.48.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.48.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.48.0",
+        "@rollup/rollup-linux-x64-gnu": "4.48.0",
+        "@rollup/rollup-linux-x64-musl": "4.48.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.48.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.48.0",
+        "@rollup/rollup-win32-x64-msvc": "4.48.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -5723,7 +6211,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -5747,7 +6236,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.90.0",
@@ -6150,10 +6640,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6200,6 +6691,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -6212,6 +6704,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6304,6 +6797,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -6311,10 +6805,58 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6323,13 +6865,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6378,11 +6922,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -6401,6 +6956,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6410,26 +6966,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6442,6 +6991,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -6458,6 +7008,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6465,11 +7016,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -6500,11 +7068,19 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6542,11 +7118,42 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
       "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
@@ -6554,63 +7161,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -6645,11 +7195,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "devOptional": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -6736,16 +7289,16 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6786,6 +7339,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -6797,13 +7351,15 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -6877,7 +7433,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -6895,9 +7452,17 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -6927,6 +7492,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -7220,19 +7786,6 @@
         "eslint": "^8.57.0 || ^9.0.0"
       }
     },
-    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/vuetify": {
       "version": "3.9.5",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.9.5.tgz",
@@ -7267,6 +7820,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
       "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
+      "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^6.0.0-beta.11"
       },
@@ -7339,6 +7893,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7432,6 +7987,7 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7441,6 +7997,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -7459,6 +8016,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7471,26 +8029,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7505,6 +8056,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7517,12 +8069,20 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -7564,9 +8124,9 @@
       "license": "MIT"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7581,6 +8141,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "vuex": "4.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "6.8.0",
     "@testing-library/user-event": "14.6.1",
     "@testing-library/vue": "8.1.0",
     "@typescript-eslint/parser": "8.40.0",
     "@vitejs/plugin-vue": "6.0.1",
     "@vitest/coverage-v8": "3.2.4",
+    "canvas": "3.2.0",
     "coveralls": "3.1.1",
     "eslint": "9.34.0",
     "jsdom": "26.1.0",

--- a/src/editor/actionable-panel/actionable-panel.test.ts
+++ b/src/editor/actionable-panel/actionable-panel.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createVuetify } from 'vuetify/framework';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { render, screen } from '@testing-library/vue';
+import ActionablePanel from '@/editor/actionable-panel/actionable-panel.vue';
+import type { Component } from 'vue';
+
+const vuetify = createVuetify({
+    components,
+    directives,
+});
+
+describe('ActionablePanel', () => {
+    beforeEach(() => {
+        const content = {
+            template: '<actionable-panel title="Test Title">Hello world</actionable-panel>',
+            components: { ActionablePanel: ActionablePanel as Component },
+        };
+        render(content, {
+            global: {
+                plugins: [vuetify],
+            },
+        });
+    });
+
+    afterEach(() => {
+        // jsdom doesn't clean up between tests in the same file
+        document.body.innerHTML = '';
+    });
+
+    it('renders the specified title', () => {
+        expect(screen.getByText('Test Title'));
+    });
+
+    it('renders the child content', () => {
+        expect(screen.getByText('Hello world'));
+    });
+});

--- a/src/editor/actionable-panel/actionable-panel.vue
+++ b/src/editor/actionable-panel/actionable-panel.vue
@@ -12,19 +12,11 @@
     </v-card>
 </template>
 
-<script lang="ts">
-export default {
-
-    name: 'ActionablePanel',
-
-    props: {
-        title: String,
-        padded: {
-            type: Boolean,
-            default: true,
-        },
-    },
-}
+<script setup lang="ts">
+const { padded = true } = defineProps<{
+    title?: string,
+    padded?: boolean
+}>();
 </script>
 
 <style lang="scss" scoped>

--- a/src/editor/app.vue
+++ b/src/editor/app.vue
@@ -9,20 +9,7 @@
     </v-app>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import NavBar from '@/editor/nav-bar.vue';
 import MainContent from '@/editor/main-content.vue';
-
-export default {
-    name: 'App',
-
-    components: {
-        NavBar,
-        MainContent
-    },
-
-    data: () => ({
-    //
-    })
-}
 </script>

--- a/src/editor/code-viewer.test.ts
+++ b/src/editor/code-viewer.test.ts
@@ -1,4 +1,3 @@
-// tests/unit/code-viewer.spec.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
@@ -7,6 +6,7 @@ import { type Plugin } from 'vue';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { render, screen } from '@testing-library/vue';
 import CodeViewer from '../../src/editor/code-viewer.vue';
+import { ZeldaGame } from '@/ZeldaGame';
 
 const mapData = { tiles: [1, 2, 3], other: 'data' };
 const mockMap = {
@@ -15,7 +15,7 @@ const mockMap = {
 
 const mockGame = {
     map: mockMap,
-};
+} as unknown as ZeldaGame;
 
 describe('CodeViewer', () => {
     let vuetify: Plugin;

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -10,5 +10,5 @@ canvas {
 }
 
 .control-group-bottom-margin {
-    margin-bottom: 24px; // Twice the east/west padding
+    margin-bottom: 24px; /* Twice the east/west padding */
 }

--- a/src/editor/enemy-selector.test.ts
+++ b/src/editor/enemy-selector.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, RenderResult, screen, within } from '@testing-library/vue';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { type Plugin } from 'vue';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import EnemySelector from '../../src/editor/enemy-selector.vue';
+import { ZeldaGame } from '@/ZeldaGame';
+import { EnemyGroup } from '@/EnemyGroup';
+
+const mapData = { tiles: [1, 2, 3], other: 'data' };
+const mockMap = {
+    toJson: vi.fn(() => mapData),
+};
+
+const mockGame = {
+    map: mockMap,
+} as unknown as ZeldaGame;
+
+describe('EnemySelector', () => {
+    let vuetify: Plugin;
+    let user: UserEvent;
+    let wrapper: RenderResult;
+
+    beforeEach(() => {
+        vuetify = createVuetify({
+            components,
+            directives,
+        });
+        user = userEvent.setup();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    describe('when there are no enemy groups yet', () => {
+        const modelValue = new EnemyGroup();
+
+        beforeEach(() => {
+            wrapper = render(EnemySelector, {
+                props: {game: mockGame, modelValue},
+                global: {plugins: [vuetify]},
+            });
+        });
+
+        it('renders an enabled button to add enemies', () => {
+            expect(screen.getByTestId('add-enemies-button')).toBeEnabled();
+        });
+
+        it('renders a disabled button to edit enemies', () => {
+            expect(screen.getByTestId('edit-enemies-button')).toBeDisabled();
+        });
+
+        it('renders a disabled button to remove enemies', () => {
+            expect(screen.getByTestId('delete-enemies-button')).toBeDisabled();
+        });
+
+        it('shows a table stating there are currently no enemies', () => {
+            const table = screen.getByRole('table');
+            const bodyRows = within(table).getAllByRole('row');
+            expect(bodyRows).toHaveLength(2); // Including header row
+            const firstRowCells = within(bodyRows[1]).getAllByRole('cell');
+            expect(firstRowCells).toHaveLength(1);
+            expect(firstRowCells[0].textContent).toEqual('No data available');
+        });
+
+        it('shows a modal to add enemies when the add button is clicked', async() => {
+            expect(screen.queryByTestId('modify-row-dialog')).toBeNull();
+            await user.click(screen.getByTestId('add-enemies-button'));
+            expect(screen.getByTestId('modify-row-dialog')).toBeInTheDocument();
+        });
+
+        describe('when enemies are added', () => {
+            beforeEach(async() => {
+                expect(screen.queryByTestId('modify-row-dialog')).not.toBeInTheDocument();
+                await user.click(screen.getByTestId('add-enemies-button'));
+                expect(screen.getByTestId('modify-row-dialog')).toBeVisible();
+
+                const select = screen.getByLabelText('Type');
+                await user.click(select);
+                const lynelOption = screen.getByText('Lynel');
+                await user.click(lynelOption);
+                const countInput = screen.getByLabelText('Count');
+                await user.clear(countInput);
+                await user.type(countInput, '3');
+            });
+
+            it('updates the model with the new value when Save is clicked', async() => {
+                await user.click(screen.getByText('Save'));
+                expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                const value = wrapper.emitted<EnemyGroup[]>()['update:modelValue'][0][0];
+                expect(value.spawnStyle).toEqual('random');
+                expect(value.enemies).toHaveLength(1);
+                expect(value.enemies[0].type).toEqual('Lynel');
+                expect(value.enemies[0].strength).toEqual('red');
+                expect(value.enemies[0].count).toEqual('3');
+            });
+
+            it('does not update the model value if Cancel is clicked', async() => {
+                await user.click(screen.getByText('Cancel'));
+                expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+            })
+        });
+    });
+
+    describe('when there is at least one group of enemies already displayed', () => {
+        const modelValue = new EnemyGroup('random', [
+            {
+                id: 'group-1',
+                type: 'Moblin',
+                strength: 'blue',
+                count: 2,
+            },
+            {
+                id: 'group-2',
+                type: 'Moblin',
+                strength: 'red',
+                count: 1,
+            },
+        ]);
+
+        beforeEach(() => {
+            wrapper = render(EnemySelector, {
+                props: {game: mockGame, modelValue},
+                global: {plugins: [vuetify]},
+            });
+        });
+
+        it('renders an enabled button to add enemies', () => {
+            expect(screen.getByTestId('add-enemies-button')).toBeEnabled();
+        });
+
+        it('renders a disabled button to edit enemies', () => {
+            expect(screen.getByTestId('edit-enemies-button')).toBeDisabled();
+        });
+
+        it('renders a disabled button to remove enemies', () => {
+            expect(screen.getByTestId('delete-enemies-button')).toBeDisabled();
+        });
+
+        it('shows a row in the table for each enemy group', () => {
+            const table = screen.getByRole('table');
+            const rows = within(table).getAllByRole('row');
+            expect(rows).toHaveLength(3); // Header + 2 enemy groups
+
+            let cols = within(rows[1]).getAllByRole('cell');
+            expect(cols).toHaveLength(4);
+            expect(cols[0].textContent).toEqual(''); // Checkbox column
+            expect(cols[1].textContent).toEqual('Moblin');
+            expect(cols[2].textContent).toEqual('blue');
+            expect(cols[3].textContent).toEqual('2');
+
+            cols = within(rows[2]).getAllByRole('cell');
+            expect(cols).toHaveLength(4);
+            expect(cols[0].textContent).toEqual(''); // Checkbox column
+            expect(cols[1].textContent).toEqual('Moblin');
+            expect(cols[2].textContent).toEqual('red');
+            expect(cols[3].textContent).toEqual('1');
+        });
+
+        describe('when a row is selected', () => {
+            beforeEach(async() => {
+                const firstRowCheckbox = screen.getAllByRole('checkbox')[0];
+                await user.click(firstRowCheckbox);
+            });
+
+            it('edit button is enabled', () => {
+                expect(screen.getByTestId('edit-enemies-button')).toBeEnabled();
+            });
+
+            it('remove button is enabled', () => {
+                expect(screen.getByTestId('delete-enemies-button')).toBeEnabled();
+            });
+
+            describe('when the edit button is clicked', () => {
+                beforeEach(async() => {
+                    expect(screen.queryByTestId('modify-row-dialog')).toBeNull();
+                    await user.click(screen.getByTestId('edit-enemies-button'));
+                });
+
+                it('displays a modal to edit the selected row', () => {
+                    expect(screen.queryByTestId('modify-row-dialog')).toBeInTheDocument();
+                });
+
+                it('prepopulates values in the modal with the selected row', () => {
+                    const modal = screen.getByTestId('modify-row-dialog');
+                    expect(within(modal).getByDisplayValue('Moblin')).toBeInTheDocument();
+                    expect(within(modal).getByDisplayValue('Blue (strong)')).toBeInTheDocument();
+                    expect(within(modal).getByDisplayValue('2')).toBeInTheDocument();
+                });
+
+                describe('when values are changed', () => {
+                    beforeEach(async() => {
+                        const select = screen.getByLabelText('Type');
+                        await user.click(select);
+                        const lynelOption = screen.getByText('Lynel');
+                        await user.click(lynelOption);
+                        const strengthInput = screen.getByLabelText('Color (Strength)');
+                        await user.click(strengthInput);
+                        const redOption = screen.getByText('Red (weak)');
+                        await user.click(redOption);
+                        const countInput = screen.getByLabelText('Count');
+                        await user.clear(countInput);
+                        await user.type(countInput, '9');
+                    });
+
+                    it('does not update the model value if Cancel is clicked', async() => {
+                        await user.click(screen.getByText('Cancel'));
+                        expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                        expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+                    });
+
+                    it('updates the model with the new value if Save is clicked', async() => {
+                        await user.click(screen.getByText('Save'));
+                        expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                        expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                        expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                        expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                        const value = wrapper.emitted<EnemyGroup[]>()['update:modelValue'][0][0];
+                        expect(value.spawnStyle).toEqual('random');
+                        expect(value.enemies).toHaveLength(2);
+
+                        // The first element is the modified enemy group
+                        expect(value.enemies[0].type).toEqual('Lynel');
+                        expect(value.enemies[0].strength).toEqual('red');
+                        expect(value.enemies[0].count).toEqual('9');
+
+                        // The second element is the unchanged enemy group
+                        expect(value.enemies[1].type).toEqual('Moblin');
+                        expect(value.enemies[1].strength).toEqual('red');
+                        expect(value.enemies[1].count).toEqual(1);
+                    });
+                });
+
+                describe('when values are not changed', () => {
+                    it('triggers a model update, but with no changes, when Save is clicked', async() => {
+                        await user.click(screen.getByText('Save'));
+                        expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                        expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                        expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                        expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                        const value = wrapper.emitted<EnemyGroup[]>()['update:modelValue'][0][0];
+                        expect(value.spawnStyle).toEqual('random');
+                        expect(value.enemies).toHaveLength(2);
+
+                        // The first element is the modified enemy group
+                        expect(value.enemies[0].type).toEqual('Moblin');
+                        expect(value.enemies[0].strength).toEqual('blue');
+                        expect(value.enemies[0].count).toEqual(2);
+
+                        // The second element is the unchanged enemy group
+                        expect(value.enemies[1].type).toEqual('Moblin');
+                        expect(value.enemies[1].strength).toEqual('red');
+                        expect(value.enemies[1].count).toEqual(1);
+                    });
+
+                    it('does not update the model value if Cancel is clicked', async() => {
+                        await user.click(screen.getByText('Cancel'));
+                        expect(screen.queryByTestId('modify-row-dialog')).not.toBeVisible();
+
+                        expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+                    });
+                });
+            });
+
+            describe('when the remove button is clicked', () => {
+                beforeEach(async() => {
+                    await user.click(screen.getByTestId('delete-enemies-button'));
+                });
+
+                it('displays a modal confirming removal of the enemy group', () => {
+                    expect(screen.getByText('Are you sure you want to delete the selected Enemy Group?'))
+                        .toBeInTheDocument();
+                });
+
+                describe('when "Yes" is clicked', () => {
+                    beforeEach(async() => {
+                        await user.click(screen.getByText('Yes'));
+                    });
+
+                    it('updates the model with the new value (without the selected enemy group)', () => {
+                        expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                        expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                        expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                        const value = wrapper.emitted<EnemyGroup[]>()['update:modelValue'][0][0];
+                        expect(value.spawnStyle).toEqual('random');
+                        expect(value.enemies).toHaveLength(1);
+                        expect(value.enemies[0].type).toEqual('Moblin');
+                        expect(value.enemies[0].strength).toEqual('red');
+                        expect(value.enemies[0].count).toEqual(1);
+                    });
+                });
+
+                describe('when "No" is clicked', () => {
+                    beforeEach(async() => {
+                        await user.click(screen.getByText('No'));
+                    });
+
+                    it('does not update the model value', () => {
+                        expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+                    });
+                })
+            })
+        });
+    });
+});

--- a/src/editor/event-editor.test.ts
+++ b/src/editor/event-editor.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, RenderResult, screen, within } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import EventEditor from './event-editor.vue';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { Plugin } from 'vue';
+import { UserEvent } from '@testing-library/user-event/index';
+import { Event, EventData } from '@/event/Event';
+import { Position } from '@/Position';
+
+function createEventMock(id: string, type = 'goDownStairs'): Event<EventData> {
+    return {
+        id,
+        type,
+        tile: new Position(1, 2),
+        destMap: 'overworld',
+        destScreen: new Position(3, 4),
+        destPos: new Position(5, 6),
+    } as unknown as Event<EventData>;
+}
+
+describe('EventEditor', () => {
+    let vuetify: Plugin;
+    let user: UserEvent;
+    let wrapper: RenderResult;
+    let modelValue: Event<EventData>[];
+
+    beforeEach(() => {
+        vuetify = createVuetify({
+            components,
+            directives,
+        });
+        user = userEvent.setup();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    describe('when no row is checked', () => {
+        beforeEach(() => {
+            modelValue = [
+                createEventMock('1'),
+                createEventMock('2', 'changeScreenWarp'),
+            ];
+            wrapper = render(EventEditor, {
+                global: { plugins: [vuetify] },
+                props: {
+                    game: {},
+                    modelValue,
+                },
+            });
+        });
+
+        it('renders an enabled button to add events', () => {
+            expect(screen.getByTestId('add-event-button')).toBeEnabled();
+        });
+
+        it('renders a disabled button to edit events', () => {
+            expect(screen.getByTestId('edit-event-button')).toBeDisabled();
+        });
+
+        it('renders a disabled button to remove events', () => {
+            expect(screen.getByTestId('delete-event-button')).toBeDisabled();
+        });
+
+        it('renders table with the proper headers', () => {
+            const table = screen.getByRole('table');
+            const bodyRows = within(table).getAllByRole('row');
+            expect(bodyRows).toHaveLength(3); // Including header row
+            const headerCells = within(bodyRows[0]).getAllByRole('columnheader');
+            expect(headerCells).toHaveLength(3);
+            expect(headerCells[0].textContent).toEqual(''); // Checkbox column
+            expect(headerCells[1].textContent).toEqual('Type');
+            expect(headerCells[2].textContent).toEqual('Description');
+        });
+
+        it('renders a row for each event', () => {
+            const table = screen.getByRole('table');
+            const bodyRows = within(table).getAllByRole('row');
+            expect(bodyRows).toHaveLength(3); // Including header row
+
+            const firstRowCells = within(bodyRows[1]).getAllByRole('cell');
+            expect(firstRowCells).toHaveLength(3);
+            expect(firstRowCells[0].textContent).toEqual('');
+            expect(firstRowCells[1].textContent).toEqual('Go Down Stairs');
+            expect(firstRowCells[2].textContent).not.toBeNull(); // TODO
+
+            const secondRowCells = within(bodyRows[2]).getAllByRole('cell');
+            expect(secondRowCells).toHaveLength(3);
+            expect(secondRowCells[0].textContent).toEqual('');
+            expect(secondRowCells[1].textContent).toEqual('Warp on Screen Change');
+            expect(secondRowCells[2].textContent).not.toBeNull(); // TODO
+        });
+
+        it('shows a modal to add events when the add button is clicked', async() => {
+            expect(screen.queryByTestId('edit-event-modal')).toBeNull();
+            await user.click(screen.getByTestId('add-event-button'));
+            expect(screen.getByTestId('edit-event-modal')).toBeInTheDocument();
+        });
+
+        describe('when events are added', () => {
+            beforeEach(async() => {
+                expect(screen.queryByTestId('edit-event-modal')).not.toBeInTheDocument();
+                await user.click(screen.getByTestId('add-event-button'));
+                expect(screen.getByTestId('edit-event-modal')).toBeVisible();
+
+                const select = screen.getByLabelText('Event Type');
+                await user.click(select);
+                const warpOption = screen.getByRole('option', { name: 'Warp on Screen Change' });
+                await user.click(warpOption);
+                const rowDropdowns = screen.getAllByLabelText('Row');
+                for (const dropdown of rowDropdowns) {
+                    await user.click(dropdown);
+                    const rowOption = screen.getByRole('option', { name: '3' });
+                    await user.click(rowOption);
+                }
+                const colDropdowns = screen.getAllByLabelText('Column');
+                for (const dropdown of colDropdowns) {
+                    await user.click(dropdown);
+                    const colOption = screen.getByRole('option', { name: '4' });
+                    await user.click(colOption);
+                }
+            });
+
+            it('updates the model with the new value when Save is clicked', async() => {
+                await user.click(screen.getByText('Save'));
+                expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+
+                expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                const value = wrapper.emitted<Event<EventData>[][]>()['update:modelValue'][0][0];
+                expect(value).toHaveLength(3);
+
+                // The first two events are the preseeded ones
+                for (let i = 0; i < 2; i++) {
+                    expect(value[i].id).toEqual((i + 1).toString());
+                    expect(value[i].type).toEqual(i === 0 ? 'goDownStairs' : 'changeScreenWarp');
+                    expect(value[i].tile.row).toEqual(1);
+                    expect(value[i].tile.col).toEqual(2);
+                    expect(value[i].destMap).toEqual('overworld');
+                    expect(value[i].destScreen.row).toEqual(3);
+                    expect(value[i].destScreen.col).toEqual(4);
+                    expect(value[i].destPos.row).toEqual(5);
+                    expect(value[i].destPos.col).toEqual(6);
+                }
+
+                // The third event is our added one
+                expect(value[2].id).not.toBeNull(); /// Randomly generated
+                expect(value[2].type).toEqual('changeScreenWarp');
+                expect(value[2].tile.row).toEqual(0);
+                expect(value[2].tile.col).toEqual(0);
+                expect(value[2].destMap).toEqual('overworld');
+                expect(value[2].destScreen.row).toEqual(3);
+                expect(value[2].destScreen.col).toEqual(4);
+                expect(value[2].destPos.row).toEqual(3);
+                expect(value[2].destPos.col).toEqual(4);
+            });
+
+            it('does not update the model value if Cancel is clicked', async() => {
+                await user.click(screen.getByText('Cancel'));
+                expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+
+                expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+            })
+        });
+    });
+
+    describe('when a row is checked', () => {
+        beforeEach(async() => {
+            modelValue = [
+                createEventMock('1'),
+                createEventMock('2', 'changeScreenWarp'),
+            ];
+            wrapper = render(EventEditor, {
+                global: { plugins: [vuetify] },
+                props: {
+                    game: {},
+                    modelValue,
+                },
+            });
+
+            const firstRowCheckbox = screen.getAllByRole('checkbox')[0];
+            await user.click(firstRowCheckbox);
+        });
+
+        it('edit button is enabled', () => {
+            expect(screen.getByTestId('edit-event-button')).toBeEnabled();
+        });
+
+        it('remove button is enabled', () => {
+            expect(screen.getByTestId('delete-event-button')).toBeEnabled();
+        });
+
+        describe('when the edit button is clicked', () => {
+            beforeEach(async() => {
+                expect(screen.queryByTestId('edit-event-modal')).toBeNull();
+                await user.click(screen.getByTestId('edit-event-button'));
+            });
+
+            it('displays a modal to edit the selected row', () => {
+                expect(screen.queryByTestId('edit-event-modal')).toBeInTheDocument();
+            });
+
+            it('prepopulates values in the modal with the selected row', () => {
+                const modal = screen.getByTestId('edit-event-modal');
+                expect(within(modal).getByDisplayValue('Go Down Stairs')).toBeInTheDocument();
+                expect(within(modal).getByDisplayValue('Overworld')).toBeInTheDocument();
+            });
+
+            describe('when values are changed', () => {
+                beforeEach(async() => {
+                    const select = screen.getByLabelText('Event Type');
+                    await user.click(select);
+                    const warpOption = screen.getByRole('option', { name: 'Warp on Screen Change' });
+                    await user.click(warpOption);
+                    const rowDropdowns = screen.getAllByLabelText('Row');
+                    for (const dropdown of rowDropdowns) {
+                        await user.click(dropdown);
+                        const rowOption = screen.getByRole('option', { name: '3' });
+                        await user.click(rowOption);
+                    }
+                    const colDropdowns = screen.getAllByLabelText('Column');
+                    for (const dropdown of colDropdowns) {
+                        await user.click(dropdown);
+                        const colOption = screen.getByRole('option', { name: '4' });
+                        await user.click(colOption);
+                    }
+                });
+
+                it('does not update the model value if Cancel is clicked', async() => {
+                    await user.click(screen.getByText('Cancel'));
+                    expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+
+                    expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+                });
+
+                it('updates the model with the new value if Save is clicked', async() => {
+                    await user.click(screen.getByText('Save'));
+                    expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+                    const value = wrapper.emitted<Event<EventData>[][]>()['update:modelValue'][0][0];
+                    expect(value).toHaveLength(2);
+
+                    // The first event is modified
+                    expect(value[0].id).not.toBeNull();
+                    expect(value[0].type).toEqual('changeScreenWarp');
+                    expect(value[0].tile.row).toEqual(1);
+                    expect(value[0].tile.col).toEqual(2);
+                    expect(value[0].destMap).toEqual('overworld');
+                    expect(value[0].destScreen.row).toEqual(3);
+                    expect(value[0].destScreen.col).toEqual(4);
+                    expect(value[0].destPos.row).toEqual(3);
+                    expect(value[0].destPos.col).toEqual(4);
+
+                    // The second event is unchanged
+                    expect(value[1].id).toEqual('2');
+                    expect(value[1].type).toEqual('changeScreenWarp');
+                    expect(value[1].tile.row).toEqual(1);
+                    expect(value[1].tile.col).toEqual(2);
+                    expect(value[1].destMap).toEqual('overworld');
+                    expect(value[1].destScreen.row).toEqual(3);
+                    expect(value[1].destScreen.col).toEqual(4);
+                    expect(value[1].destPos.row).toEqual(5);
+                    expect(value[1].destPos.col).toEqual(6);
+                });
+            });
+
+            describe('when values are not changed', () => {
+                it('triggers a model update, but with no changes, when Save is clicked', async() => {
+                    await user.click(screen.getByText('Save'));
+                    expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+
+                    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+                    expect(wrapper.emitted()['update:modelValue']).toHaveLength(1);
+                    expect(wrapper.emitted()['update:modelValue'][0]).toHaveLength(1);
+                    const value = wrapper.emitted<Event<EventData>[][]>()['update:modelValue'][0][0];
+                    expect(value).toHaveLength(2);
+
+                    // The two events are unchanged
+                    for (let i = 0; i < 2; i++) {
+                        expect(value[i].id).not.toBeNull();
+                        expect(value[i].type).toEqual(i === 0 ? 'goDownStairs' : 'changeScreenWarp');
+                        expect(value[i].tile.row).toEqual(1);
+                        expect(value[i].tile.col).toEqual(2);
+                        expect(value[i].destMap).toEqual('overworld');
+                        expect(value[i].destScreen.row).toEqual(3);
+                        expect(value[i].destScreen.col).toEqual(4);
+                        expect(value[i].destPos.row).toEqual(5);
+                        expect(value[i].destPos.col).toEqual(6);
+                    }
+                });
+
+                it('does not update the model value if Cancel is clicked', async() => {
+                    await user.click(screen.getByText('Cancel'));
+                    expect(screen.queryByTestId('edit-event-modal')).not.toBeVisible();
+
+                    expect(wrapper.emitted()).not.toHaveProperty('update:modelValue');
+                });
+            });
+        });
+    });
+});

--- a/src/editor/event-generators.test.ts
+++ b/src/editor/event-generators.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { GoDownStairsEventGenerator, ChangeScreenWarpEventGenerator } from './event-generators';
+import { Position } from '../Position';
+
+describe('GoDownStairsEventGenerator', () => {
+    describe('generate()', () => {
+        it('works', () => {
+            const gen = new GoDownStairsEventGenerator();
+            gen.setTile(new Position(3, 4));
+            gen.setDestination('map', new Position(1, 1), new Position(2, 2));
+            const actual = gen.generate();
+            expect(actual.tile).toEqual(new Position(3, 4));
+            expect(actual.destMap).toEqual('map');
+            expect(actual.destScreen).toEqual(new Position(1, 1));
+            expect(actual.destPos).toEqual(new Position(2, 2));
+            expect(actual.getAnimate()).toEqual(true);
+        });
+    });
+});
+
+describe('ChangeScreenWarpEventGenerator', () => {
+    describe('generate()', () => {
+        it('works', () => {
+            const gen = new ChangeScreenWarpEventGenerator();
+            gen.setTile(new Position(3, 4));
+            gen.setDestination('map', new Position(1, 1), new Position(2, 2));
+            const actual = gen.generate();
+            expect(actual.tile).toEqual(new Position(3, 4));
+            expect(actual.destMap).toEqual('map');
+            expect(actual.destScreen).toEqual(new Position(1, 1));
+            expect(actual.destPos).toEqual(new Position(2, 2));
+            expect(actual.getAnimate()).toEqual(true);
+        });
+    });
+});

--- a/src/editor/event-generators.ts
+++ b/src/editor/event-generators.ts
@@ -43,10 +43,6 @@ export class GoDownStairsEventGenerator extends EventGenerator<GoDownStairsEvent
     generate(): GoDownStairsEvent {
         return new GoDownStairsEvent(this.tile, this.destMap, this.destScreen, this.destPos, true, true);
     }
-
-    override toString(): string {
-        return '[GoDownStairsEventGenerator]';
-    }
 }
 
 export class ChangeScreenWarpEventGenerator extends EventGenerator<ChangeScreenWarpEvent> {
@@ -58,9 +54,5 @@ export class ChangeScreenWarpEventGenerator extends EventGenerator<ChangeScreenW
 
     generate(): ChangeScreenWarpEvent {
         return new ChangeScreenWarpEvent(this.tile, this.destMap, this.destScreen, this.destPos, true);
-    }
-
-    override toString(): string {
-        return '[ChangeScreenWarpEventGenerator]';
     }
 }

--- a/src/editor/event-loader.test.ts
+++ b/src/editor/event-loader.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import loadEvent from './event-loader';
+import { GoDownStairsEvent } from '../event/GoDownStairsEvent';
+import { ChangeScreenWarpEvent } from '../event/ChangeScreenWarpEvent';
+import { EventData } from '@/event/Event';
+
+describe('loadEvent', () => {
+    it('loads a goDownStairs event', () => {
+        const data = {
+            animate: true,
+            type: 'goDownStairs',
+            tile: { row: 1, col: 2 },
+            destMap: 'level1',
+            destScreen: { row: 3, col: 4 },
+            destPos: { row: 5, col: 6 },
+        };
+        const event = loadEvent(data);
+        expect(event).toBeInstanceOf(GoDownStairsEvent);
+        expect(event.tile.row).toBe(1);
+        expect(event.tile.col).toBe(2);
+        expect(event.destMap).toBe('level1');
+        expect(event.destScreen.row).toBe(3);
+        expect(event.destScreen.col).toBe(4);
+        expect(event.destPos.row).toBe(5);
+        expect(event.destPos.col).toBe(6);
+    });
+
+    it('loads a changeScreenWarp event', () => {
+        const data: EventData = {
+            type: 'changeScreenWarp',
+            destMap: 'overworld',
+            destScreen: { row: 7, col: 8 },
+            destPos: { row: 9, col: 10 },
+            tile: { row: 0, col: 0 },
+            animate: true,
+        };
+        const event = loadEvent(data);
+        expect(event).toBeInstanceOf(ChangeScreenWarpEvent);
+        expect(event.destMap).toBe('overworld');
+        expect(event.destScreen.row).toBe(7);
+        expect(event.destScreen.col).toBe(8);
+        expect(event.destPos.row).toBe(9);
+        expect(event.destPos.col).toBe(10);
+    });
+
+    it('throws for unknown event type', () => {
+        const data: EventData = {
+            type: 'unknownType',
+            tile: { row: 0, col: 0 },
+            animate: true,
+            destMap: 'overworld',
+            destScreen: { row: 0, col: 0 },
+            destPos:  { row: 0, col: 0 },
+        };
+        expect(() => loadEvent(data)).toThrow(/Unknown event type/);
+    });
+});

--- a/src/editor/main-content.test.ts
+++ b/src/editor/main-content.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/vue';
+import MainContent from './main-content.vue';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { EnemyGroup } from '@/EnemyGroup';
+import { fireEvent } from '@testing-library/vue';
+
+const mocks = vi.hoisted(() => {
+    const mockCommit = vi.fn();
+    return {
+        useStore: () => ({
+            state: {
+                currentScreen: mockScreen,
+                currentScreenCol: 1,
+                currentScreenRow: 1,
+                game: mockGame,
+                lastModified: 0,
+            },
+            commit: mockCommit
+        }),
+    };
+});
+
+vi.mock('vuex', () => ({
+    useStore: mocks.useStore,
+}));
+
+const mockScreen = {
+    enemyGroup: new EnemyGroup(),
+    paint: vi.fn(),
+    paintCol: vi.fn(),
+    paintRow: vi.fn(),
+    paintTopLayer: vi.fn(),
+};
+
+const mockGame = {
+    assets: {
+        addImage: vi.fn(),
+        addJson: vi.fn(),
+        addSpriteSheet: vi.fn(),
+        get: vi.fn(),
+        onLoad: vi.fn((callback: () => void) => {
+            callback();
+        }),
+    },
+    map: {
+        currentScreen: mockScreen,
+        currentScreenRow: 1,
+        currentScreenCol: 1,
+        rowCount: 10,
+        colCount: 10,
+        getScreen: vi.fn(() => mockScreen),
+        tileset: {
+            getName: vi.fn(),
+            paintTile: vi.fn(),
+        },
+    },
+    startNewGame: vi.fn(),
+};
+
+const vuetify = createVuetify({
+    components,
+    directives,
+});
+
+describe('MainContent', () => {
+    beforeEach(() => {
+        render(MainContent, {
+            global: {
+                plugins: [vuetify],
+            },
+        });
+    });
+
+    afterEach(() => {
+        // jsdom doesn't clean up between tests in the same file
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('renders the map editor', () => {
+        expect(screen.getByText(/Screen \(\d+, \d+\) \/ \(\d+, \d+\)/));
+    });
+
+    it('renders tab labels for the Tile Palette/Events/Misc pane', async() => {
+        await waitFor(() => {
+            expect(screen.getByText(/Tile Palette/i)).toBeTruthy();
+            expect(screen.getByText(/Events/i)).toBeTruthy();
+            expect(screen.getByText(/Misc/i)).toBeTruthy();
+        });
+    });
+
+    it('shows the Tile Palette by default', () => {
+        expect(screen.getByText('Tile Palette'));
+    });
+
+    it('renders the map preview', () => {
+        expect(screen.getByText('Map Preview'));
+    });
+
+    it('renders the code viewer', () => {
+        expect(screen.getByText('Map JSON'));
+    });
+
+    describe('when the left arrow key is pressed', () => {
+        beforeEach(async() => {
+            const e = {key: 'ArrowLeft', which: 37, code: 'ArrowLeft'};
+            await fireEvent(document, new KeyboardEvent('keydown', e));
+        });
+
+        it('moves the current screen one to the left', () => {
+            // Initial loading, then from the keypress
+            expect(mocks.useStore().commit).toHaveBeenLastCalledWith('setCurrentScreen', {row: 1, col: 0});
+        });
+    });
+
+    describe('when the right arrow key is pressed', () => {
+        beforeEach(async() => {
+            const e = {key: 'ArrowRight', which: 39, code: 'ArrowRight'};
+            await fireEvent(document, new KeyboardEvent('keydown', e));
+        });
+
+        it('moves the current screen one to the right', () => {
+            // Initial loading, then from the keypress
+            expect(mocks.useStore().commit).toHaveBeenLastCalledWith('setCurrentScreen', { row: 1, col: 2 });
+        });
+    });
+
+    describe('when the up arrow key is pressed', () => {
+        beforeEach(async() => {
+            const e = {key: 'ArrowUp', which: 38, code: 'ArrowUp'};
+            await fireEvent(document, new KeyboardEvent('keydown', e));
+        });
+
+        it('moves the current screen one to the right', () => {
+            // Initial loading, then from the keypress
+            expect(mocks.useStore().commit).toHaveBeenLastCalledWith('setCurrentScreen', { row: 0, col: 1 });
+        });
+    });
+
+    describe('when the down arrow key is pressed', () => {
+        beforeEach(async() => {
+            const e = {key: 'ArrowDown', which: 40, code: 'ArrowDown'};
+            await fireEvent(document, new KeyboardEvent('keydown', e));
+        });
+
+        it('moves the current screen one to the right', () => {
+            // Initial loading, then from the keypress
+            expect(mocks.useStore().commit).toHaveBeenLastCalledWith('setCurrentScreen', { row: 2, col: 1 });
+        });
+    });
+});

--- a/src/editor/map-editor.test.ts
+++ b/src/editor/map-editor.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import MapEditor from './map-editor.vue';
+import { createVuetify } from 'vuetify';
+
+const vuetify = createVuetify();
+
+const mockScreen = {
+    paint: vi.fn(),
+    paintCol: vi.fn(),
+    paintRow: vi.fn(),
+    paintTopLayer: vi.fn(),
+    setTile: vi.fn(),
+};
+const mockMap = {
+    currentScreen: mockScreen,
+    currentScreenRow: 1,
+    currentScreenCol: 1,
+    rowCount: 3,
+    colCount: 3,
+    getScreen: vi.fn(() => mockScreen),
+    tileset: {
+        paintTile: vi.fn(),
+    },
+};
+
+describe('MapEditor', () => {
+    let mockGame = { map: mockMap };
+    let user: UserEvent;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
+    });
+
+    it('renders the canvas after a short delay', () => {
+        render(MapEditor, {
+            global: {
+                plugins: [vuetify],
+            },
+            props: {
+                game: mockGame,
+                selectedTileIndex: 1,
+            },
+        });
+
+        vi.advanceTimersByTime(50);
+
+        // The current screen is painted
+        expect(mockScreen.paint).toHaveBeenCalledOnce();
+
+        // Top, bottom, left and right screens have 1 row/column painted
+        expect(mockScreen.paintRow).toHaveBeenCalledTimes(2);
+        expect(mockScreen.paintCol).toHaveBeenCalledTimes(2);
+
+        // The armed tile is painted
+        expect(mockMap.tileset.paintTile).toHaveBeenCalledOnce();
+    });
+
+    describe('when viewing the top-left screen', () => {
+        it('renders the canvas after a short delay', () => {
+            mockGame = {
+                map: {
+                    ...mockGame.map,
+                    currentScreenRow: 0,
+                    currentScreenCol: 0,
+                },
+            };
+
+            render(MapEditor, {
+                global: {
+                    plugins: [vuetify],
+                },
+                props: {
+                    game: mockGame,
+                    selectedTileIndex: 1,
+                },
+            });
+
+            vi.advanceTimersByTime(50);
+
+            // The current screen is painted
+            expect(mockScreen.paint).toHaveBeenCalledOnce();
+
+            // Only the bottom and right screens have 1 row/column painted
+            expect(mockScreen.paintRow).toHaveBeenCalledTimes(1);
+            expect(mockScreen.paintCol).toHaveBeenCalledTimes(1);
+
+            // The armed tile is painted
+            expect(mockMap.tileset.paintTile).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('when viewing the bottom-right screen', () => {
+        it('renders the canvas after a short delay', () => {
+            mockGame = {
+                map: {
+                    ...mockGame.map,
+                    currentScreenRow: 2,
+                    currentScreenCol: 2,
+                },
+            };
+
+            render(MapEditor, {
+                global: {
+                    plugins: [vuetify],
+                },
+                props: {
+                    game: mockGame,
+                    selectedTileIndex: 1,
+                },
+            });
+
+            vi.advanceTimersByTime(50);
+
+            // The current screen is painted
+            expect(mockScreen.paint).toHaveBeenCalledOnce();
+
+            // Only the bottom and right screens have 1 row/column painted
+            expect(mockScreen.paintRow).toHaveBeenCalledTimes(1);
+            expect(mockScreen.paintCol).toHaveBeenCalledTimes(1);
+
+            // The armed tile is painted
+            expect(mockMap.tileset.paintTile).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('if the mouse moves around in the screen', () => {
+        it('rerenders', async() => {
+            render(MapEditor, {
+                global: {
+                    plugins: [vuetify],
+                },
+                props: {
+                    game: mockGame,
+                    selectedTileIndex: 1,
+                },
+            });
+
+            // Simulate the mouse being in one screen and moving to another
+            const canvas = screen.getByLabelText('The current screen editor');
+            await user.pointer({
+                target: canvas,
+                coords: { x: 75, y: 42 },
+            });
+            await user.pointer({
+                target: canvas,
+                coords: { x: 100, y: 100 },
+            });
+        });
+    });
+
+    describe('if the mouse updates some tiles on the screen', () => {
+        it('rerenders', async() => {
+            render(MapEditor, {
+                global: {
+                    plugins: [vuetify],
+                },
+                props: {
+                    game: mockGame,
+                    selectedTileIndex: 1,
+                },
+            });
+
+            // Simulate the click and dragging from onet ile to another
+            const canvas = screen.getByLabelText('The current screen editor');
+            await user.pointer({
+                keys: '[MouseLeft>]',
+                target: canvas,
+                coords: { x: 75, y: 42 },
+            });
+            await user.pointer({
+                keys: '[/MouseLeft]',
+                target: canvas,
+                coords: { x: 100, y: 100 },
+            });
+        });
+    });
+});

--- a/src/editor/map-editor.vue
+++ b/src/editor/map-editor.vue
@@ -3,198 +3,163 @@
 
         <!-- 256x176 + 16-pixel buffer on all sides -->
         <canvas class="screen-canvas" width="288" height="208"
+                aria-label="The current screen editor"
                 ref="canvas"/>
     </div>
 </template>
 
-<script lang="ts">
-import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT, SCREEN_WIDTH } from '@/Constants';
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useStore } from 'vuex';
 import debounce from 'debounce';
-import { Map } from '../Map';
-import { Screen } from '../Screen';
-import ActionablePanel from '@/editor/actionable-panel/actionable-panel.vue';
+import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT, SCREEN_WIDTH } from '@/Constants';
 
-export default {
+const props = defineProps<{
+    game: any,
+    selectedTileIndex: number,
+}>();
 
-    name: 'MapEditor',
-    components: {
-        ActionablePanel,
-    },
+const canvas = ref<HTMLCanvasElement | null>(null);
+const armedRow = ref(0);
+const armedCol = ref(0);
+const mouseDown = ref(false);
+const store = useStore();
 
-    props: {
-        game: Object, // ZeldaGame,
-        selectedTileIndex: Number,
-    },
-
-    data() {
-        return {
-            armedRow: 0,
-            armedCol: 0,
-            _mouseDown: false,
-        };
-    },
-
-    methods: {
-        inMainScreen(x: number, y: number) {
-            return x >= 32 && x < SCREEN_WIDTH * 2 + 32 &&
-                y >= 32 && y < SCREEN_HEIGHT * 2 + 32;
-        },
-
-        mapChanged(e: MouseEvent | null) {
-            const screen: Screen = this.game.map.currentScreen;
-            const selectedTileIndex: number = this.selectedTileIndex;
-            screen.setTile(this.armedRow, this.armedCol, selectedTileIndex);
-            this.updateLastModified();
-        },
-
-        paintScreenAbovePart(ctx: CanvasRenderingContext2D) {
-            const map: Map = this.game.map;
-            if (map && map.currentScreenRow > 0) {
-                ctx.translate(16, 0);
-                const screen: Screen = map.getScreen(map.currentScreenRow - 1, map.currentScreenCol);
-                screen.paintRow(ctx, SCREEN_ROW_COUNT - 1, 0);
-                ctx.translate(-16, 0);
-            }
-            else {
-                ctx.fillStyle = 'darkgray';
-                ctx.fillRect(16, 0, SCREEN_WIDTH, 16);
-            }
-        },
-
-        paintScreenRightPart(ctx: CanvasRenderingContext2D) {
-            const map: Map = this.game.map;
-            if (map && map.currentScreenCol < map.colCount - 1) {
-                ctx.translate(0, 16);
-                const screen: Screen = map.getScreen(map.currentScreenRow, map.currentScreenCol + 1);
-                screen.paintCol(ctx, 0, SCREEN_WIDTH + 16);
-                ctx.translate(0, -16);
-            }
-            else {
-                ctx.fillStyle = 'darkgray';
-                const x: number = SCREEN_WIDTH + 16;
-                ctx.fillRect(x, 16, 16, SCREEN_HEIGHT);
-            }
-        },
-
-        paintScreenBelowPart(ctx: CanvasRenderingContext2D) {
-            const map: Map = this.game.map;
-            if (map && map.currentScreenRow < map.rowCount - 1) {
-                ctx.translate(16, 0);
-                const screen: Screen = map.getScreen(map.currentScreenRow + 1, map.currentScreenCol);
-                screen.paintRow(ctx, 0, SCREEN_HEIGHT + 16);
-                ctx.translate(-16, 0);
-            }
-            else {
-                ctx.fillStyle = 'darkgray';
-                const y: number = SCREEN_HEIGHT + 16;
-                ctx.fillRect(16, y, SCREEN_WIDTH, 16);
-            }
-        },
-
-        paintScreenLeftPart(ctx: CanvasRenderingContext2D) {
-            const map: Map = this.game.map;
-            if (map && map.currentScreenCol > 0) {
-                ctx.translate(0, 16);
-                const screen: Screen = map.getScreen(map.currentScreenRow, map.currentScreenCol - 1);
-                screen.paintCol(ctx, SCREEN_COL_COUNT - 1, 0);
-                ctx.translate(0, -16);
-            }
-            else {
-                ctx.fillStyle = 'darkgray';
-                ctx.fillRect(0, 16, 16, SCREEN_HEIGHT);
-            }
-        },
-
-        possiblyPaintArmedTile(ctx: CanvasRenderingContext2D) {
-            const armedRow: number = this.armedRow;
-            const armedCol: number = this.armedCol;
-            if (armedRow > -1 && armedCol > -1) {
-                const x: number = armedCol * 16 + 16;
-                const y: number = armedRow * 16 + 16;
-                ctx.globalAlpha = 0.5;
-                this.game.map.tileset.paintTile(ctx, this.selectedTileIndex, x, y);
-                ctx.globalAlpha = 1;
-            }
-        },
-
-        paintScreen() {
-            if (this.game && this.$refs.canvas) {
-                const map: Map = this.game.map;
-                const canvas: HTMLCanvasElement = this.$refs.canvas as HTMLCanvasElement;
-                const ctx: CanvasRenderingContext2D = canvas.getContext('2d')!;
-
-                // Clear needed for translucent parts
-                ctx.fillStyle = 'white';
-                ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-
-                ctx.globalAlpha = 0.5;
-                this.paintScreenAbovePart(ctx);
-                this.paintScreenRightPart(ctx);
-                this.paintScreenBelowPart(ctx);
-                this.paintScreenLeftPart(ctx);
-                ctx.globalAlpha = 1;
-
-                ctx.translate(16, 16);
-                map.currentScreen.paint(ctx);
-                map.currentScreen.paintTopLayer(ctx);
-                ctx.translate(-16, -16);
-
-                this.possiblyPaintArmedTile(ctx);
-            }
-        },
-
-        /**
-         * This is in a separate method so we can debounce it.  Doing a vuex $store.commit() on mouse move
-         * events results in a little lag when the mouse moves quickly.
-         */
-        updateLastModified() {
-            this.$store.commit('updateLastModified');
-        },
-    },
-
-    mounted() {
-        const canvas: HTMLCanvasElement = this.$refs.canvas as HTMLCanvasElement;
-        canvas.addEventListener('mousemove', (e: MouseEvent) => {
-            let x: number = e.offsetX;
-            let y: number = e.offsetY;
-
-            if (this.inMainScreen(x, y)) {
-                x -= 32;
-                y -= 32;
-                this.armedRow = Math.floor(y / 32);
-                this.armedCol = Math.floor(x / 32);
-                console.log('armed tile: ' + this.armedRow, this.armedCol);
-                if (this._mouseDown) {
-                    this.mapChanged(null);
-                }
-            }
-            else {
-                this.armedRow = this.armedCol = -1;
-            }
-        });
-
-        canvas.addEventListener('mousedown', (e: MouseEvent) => {
-            this._mouseDown = true;
-        });
-        const mouseUpHandler: EventListener = (e: MouseEvent) => {
-            this._mouseDown = false;
-        };
-        canvas.addEventListener('mouseup', mouseUpHandler);
-        canvas.addEventListener('mouseleave', mouseUpHandler);
-
-        canvas.addEventListener('click', this.mapChanged);
-
-        setInterval(this.paintScreen, 50);
-
-        // this.$root.$on('focusCanvas', () => {
-        //     canvas.focus();
-        // });
-
-        // Fast mouse moves results in a little lag, so we debounce updates to the
-        // lastUpdated value in the store
-        this.updateLastModified = debounce(this.updateLastModified, 100);
-    },
+function inMainScreen(x: number, y: number) {
+    return x >= 32 && x < SCREEN_WIDTH * 2 + 32 &&
+        y >= 32 && y < SCREEN_HEIGHT * 2 + 32;
 }
+
+function mapChanged(e: MouseEvent | null) {
+    const screen = props.game.map.currentScreen;
+    const selectedTileIndex = props.selectedTileIndex;
+    screen.setTile(armedRow.value, armedCol.value, selectedTileIndex);
+    updateLastModified();
+}
+
+function paintScreenAbovePart(ctx: CanvasRenderingContext2D) {
+    const map = props.game.map;
+    if (map && map.currentScreenRow > 0) {
+        ctx.translate(16, 0);
+        const screen = map.getScreen(map.currentScreenRow - 1, map.currentScreenCol);
+        screen.paintRow(ctx, SCREEN_ROW_COUNT - 1, 0);
+        ctx.translate(-16, 0);
+    } else {
+        ctx.fillStyle = 'darkgray';
+        ctx.fillRect(16, 0, SCREEN_WIDTH, 16);
+    }
+}
+
+function paintScreenRightPart(ctx: CanvasRenderingContext2D) {
+    const map = props.game.map;
+    if (map && map.currentScreenCol < map.colCount - 1) {
+        ctx.translate(0, 16);
+        const screen = map.getScreen(map.currentScreenRow, map.currentScreenCol + 1);
+        screen.paintCol(ctx, 0, SCREEN_WIDTH + 16);
+        ctx.translate(0, -16);
+    } else {
+        ctx.fillStyle = 'darkgray';
+        const x = SCREEN_WIDTH + 16;
+        ctx.fillRect(x, 16, 16, SCREEN_HEIGHT);
+    }
+}
+
+function paintScreenBelowPart(ctx: CanvasRenderingContext2D) {
+    const map = props.game.map;
+    if (map && map.currentScreenRow < map.rowCount - 1) {
+        ctx.translate(16, 0);
+        const screen = map.getScreen(map.currentScreenRow + 1, map.currentScreenCol);
+        screen.paintRow(ctx, 0, SCREEN_HEIGHT + 16);
+        ctx.translate(-16, 0);
+    } else {
+        ctx.fillStyle = 'darkgray';
+        const y = SCREEN_HEIGHT + 16;
+        ctx.fillRect(16, y, SCREEN_WIDTH, 16);
+    }
+}
+
+function paintScreenLeftPart(ctx: CanvasRenderingContext2D) {
+    const map = props.game.map;
+    if (map && map.currentScreenCol > 0) {
+        ctx.translate(0, 16);
+        const screen = map.getScreen(map.currentScreenRow, map.currentScreenCol - 1);
+        screen.paintCol(ctx, SCREEN_COL_COUNT - 1, 0);
+        ctx.translate(0, -16);
+    } else {
+        ctx.fillStyle = 'darkgray';
+        ctx.fillRect(0, 16, 16, SCREEN_HEIGHT);
+    }
+}
+
+function possiblyPaintArmedTile(ctx: CanvasRenderingContext2D) {
+    if (armedRow.value > -1 && armedCol.value > -1) {
+        const x = armedCol.value * 16 + 16;
+        const y = armedRow.value * 16 + 16;
+        ctx.globalAlpha = 0.5;
+        props.game.map.tileset.paintTile(ctx, props.selectedTileIndex, x, y);
+        ctx.globalAlpha = 1;
+    }
+}
+
+function paintScreen() {
+    if (props.game && canvas.value) {
+        const map = props.game.map;
+        const ctx = canvas.value.getContext('2d')!;
+        ctx.fillStyle = 'white';
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+        ctx.globalAlpha = 0.5;
+        paintScreenAbovePart(ctx);
+        paintScreenRightPart(ctx);
+        paintScreenBelowPart(ctx);
+        paintScreenLeftPart(ctx);
+        ctx.globalAlpha = 1;
+
+        ctx.translate(16, 16);
+        map.currentScreen.paint(ctx);
+        map.currentScreen.paintTopLayer(ctx);
+        ctx.translate(-16, -16);
+
+        possiblyPaintArmedTile(ctx);
+    }
+}
+
+const updateLastModified = debounce(() => {
+    store.commit('updateLastModified');
+}, 100);
+
+onMounted(() => {
+    const el = canvas.value!;
+    el.addEventListener('mousemove', (e: MouseEvent) => {
+        let x = e.offsetX;
+        let y = e.offsetY;
+
+        if (inMainScreen(x, y)) {
+            x -= 32;
+            y -= 32;
+            armedRow.value = Math.floor(y / 32);
+            armedCol.value = Math.floor(x / 32);
+            if (mouseDown.value) {
+                mapChanged(null);
+            }
+        } else {
+            armedRow.value = armedCol.value = -1;
+        }
+    });
+
+    el.addEventListener('mousedown', () => {
+        mouseDown.value = true;
+    });
+    const mouseUpHandler = () => {
+        mouseDown.value = false;
+    };
+    el.addEventListener('mouseup', mouseUpHandler);
+    el.addEventListener('mouseleave', mouseUpHandler);
+
+    el.addEventListener('click', mapChanged);
+
+    setInterval(paintScreen, 50);
+});
 </script>
 
 <style lang="scss" scoped>

--- a/src/editor/map-preview.test.ts
+++ b/src/editor/map-preview.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import MapPreview from './map-preview.vue';
+import { createVuetify } from 'vuetify';
+
+const vuetify = createVuetify();
+
+const mockScreen = {
+    paint: vi.fn(),
+    paintTopLayer: vi.fn(),
+};
+
+const mocks = vi.hoisted(() => {
+    const mockCommit = vi.fn();
+    return {
+        useStore: () => ({
+            state: {
+                currentScreen: mockScreen,
+            },
+            commit: mockCommit
+        }),
+    };
+});
+
+vi.mock('vuex', () => ({
+    useStore: mocks.useStore,
+}));
+const mockGame = {
+    map: {
+        rowCount: 2,
+        colCount: 2,
+        getScreen: vi.fn(() => mockScreen),
+    },
+};
+const screenCount = mockGame.map.rowCount * mockGame.map.colCount;
+
+describe('MapPreview', () => {
+    beforeEach(() => {
+        render(MapPreview, {
+            global: {
+                plugins: [vuetify],
+            },
+            props: {
+                game: mockGame,
+                map: mockGame.map,
+                lastModified: 0,
+            },
+        });
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+    });
+
+    it('paints the entire map on mount', () => {
+        expect(mockGame.map.getScreen).toHaveBeenCalledTimes(screenCount);
+        // In real life each screen returned is different, but since we're mocking things it isn't.
+        // That's OK as we're just verifying that the method is called once for every screen in the map.
+        const screen = mockGame.map.getScreen();
+        expect(screen.paint).toHaveBeenCalledTimes(screenCount);
+        expect(screen.paintTopLayer).toHaveBeenCalledTimes(screenCount);
+    });
+
+    it('repaints if the mouse moves around and arms a different screen', async() => {
+        // Reset mock counts back to 0
+        mockScreen.paint.mockClear();
+        mockScreen.paintTopLayer.mockClear();
+        expect(mockScreen.paint).not.toHaveBeenCalled();
+
+        // Simulate the mouse being in one screen and moving to another
+        const canvas = screen.getByLabelText('A preview of the map');
+        await userEvent.pointer({
+            target: canvas,
+            coords: { x: 75, y: 42 },
+        });
+        await userEvent.pointer({
+            target: canvas,
+            coords: { x: 100, y: 100 },
+        });
+
+        expect(mockScreen.paint).toHaveBeenCalledTimes(screenCount);
+        expect(mockScreen.paintTopLayer).toHaveBeenCalledTimes(screenCount);
+    });
+
+    it('fires an event if the selected screen changes', async() => {
+        const canvas = screen.getByLabelText('A preview of the map');
+        await userEvent.pointer({
+            keys: '[MouseLeft]',
+            target: canvas,
+            coords: { x: 75, y: 42 },
+        });
+
+        expect(mocks.useStore().commit).toHaveBeenCalledWith('setCurrentScreen',
+            { row: expect.any(Number) as number, col: expect.any(Number) as number });
+    });
+});

--- a/src/editor/map-preview.vue
+++ b/src/editor/map-preview.vue
@@ -1,150 +1,124 @@
 <template>
     <canvas :width="canvasStyleWidth" :height="canvasStyleHeight"
+            aria-label="A preview of the map"
             class="map-preview-canvas" ref="canvas"
             @mousemove="updateArmedScreen"
             @mouseleave="clearArmedScreen"
             @click="updateSelectedScreen"/>
 </template>
 
-<script lang="ts">
-import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT, SCREEN_WIDTH } from '@/Constants';
-import { Map } from '@/Map';
-import { Screen } from '@/Screen';
-import RowColumnPair from '@/RowColumnPair';
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useStore } from 'vuex';
 import debounce from 'debounce';
+import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT, SCREEN_WIDTH } from '@/Constants';
 
-export default {
+const props = defineProps<{
+    game: any,
+    map: any,
+    lastModified: number,
+}>();
 
-    name: 'MapPreview',
+const canvas = ref<HTMLCanvasElement | null>(null);
+const armedScreenRow = ref(-1);
+const armedScreenCol = ref(-1);
+const debouncedRepaint = ref<(() => void) | null>(null);
 
-    props: {
-        game: Object, // ZeldaGame
-        map: Object, // Map
-        lastModified: Number,
-    },
+const store = useStore();
 
-    data() {
-        return {
-            armedScreenRow: -1,
-            armedScreenCol: -1,
+const currentScreen = computed(() => store.state.currentScreen);
 
-            debouncedRepaint: null, //Function | null = null;
-        };
-    },
+const canvasStyleHeight = computed(() => SCREEN_HEIGHT * SCREEN_ROW_COUNT);
+const canvasStyleWidth = computed(() => SCREEN_WIDTH * SCREEN_COL_COUNT);
 
-    methods: {
-        clearArmedScreen() {
-            this.armedScreenRow = this.armedScreenCol = -1;
-            this.repaint();
-        },
-
-        repaint() {
-            const canvas: HTMLCanvasElement = this.$refs.canvas as HTMLCanvasElement;
-
-            const ctx: CanvasRenderingContext2D = canvas.getContext('2d')!;
-            ctx.save();
-
-            ctx.fillStyle = 'white';
-            ctx.fillRect(0, 0, SCREEN_WIDTH * SCREEN_COL_COUNT,
-                SCREEN_HEIGHT * SCREEN_ROW_COUNT);
-
-            const map: Map = this.game.map;
-            for (let row = 0; row < map.rowCount; row++) {
-                for (let col = 0; col < map.colCount; col++) {
-                    const screen: Screen = map.getScreen(row, col);
-                    screen.paint(ctx);
-                    screen.paintTopLayer(ctx);
-
-                    const currentScreenRow: number = this.$store.state.currentScreenRow;
-                    const currentScreenCol: number = this.$store.state.currentScreenCol;
-                    this.possiblyOutlineScreen(ctx, row, col, currentScreenRow, currentScreenCol, 'red');
-                    this.possiblyOutlineScreen(ctx, row, col, this.armedScreenRow, this.armedScreenCol, 'blue');
-
-                    ctx.translate(SCREEN_WIDTH, 0);
-                }
-
-                const xToZero: number = -SCREEN_WIDTH * map.colCount;
-                ctx.translate(xToZero, SCREEN_HEIGHT);
-            }
-
-            ctx.restore();
-            console.log('Done repainting');
-        },
-
-        mouseEventToScreen(e: MouseEvent): RowColumnPair {
-            // e = Mouse click event.
-            const rect: DOMRect = (e.target as HTMLCanvasElement).getBoundingClientRect();
-            const x: number = e.clientX - rect.left;
-            const y: number = e.clientY - rect.top;
-
-            const canvas: HTMLCanvasElement = this.$refs.canvas as HTMLCanvasElement;
-            const canvasWidth: number = canvas.clientWidth;
-            const canvasHeight: number = canvas.clientHeight;
-
-            const virtualScreenWidth: number = canvasWidth / SCREEN_COL_COUNT;
-            const virtualScreenHeight: number = canvasHeight / SCREEN_ROW_COUNT;
-
-            const row: number = Math.floor(y / virtualScreenHeight);
-            const col: number = Math.floor(x / virtualScreenWidth);
-
-            return { row, col };
-        },
-
-        possiblyOutlineScreen(ctx: CanvasRenderingContext2D, row: number, col: number,
-            targetRow: number, targetCol: number, style: string) {
-            if (row === targetRow && col === targetCol) {
-                ctx.strokeStyle = style;
-                ctx.lineWidth = 10;
-                ctx.strokeRect(0, 0, SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10);
-            }
-        },
-
-        updateArmedScreen(e: MouseEvent) {
-            const { row, col } = this.mouseEventToScreen(e);
-
-            // Only repaint if armed screen changes since the repaint is expensive
-            if (row !== this.armedScreenRow || col !== this.armedScreenCol) {
-                this.armedScreenRow = row;
-                this.armedScreenCol = col;
-                this.repaint();
-            }
-        },
-
-        updateSelectedScreen(e: MouseEvent) {
-            const { row, col } = this.mouseEventToScreen(e);
-            this.$store.commit('setCurrentScreen', { row, col });
-        },
-    },
-
-    computed: {
-        currentScreen(): Screen | null {
-            return this.$store.state.currentScreen;
-        },
-
-        canvasStyleHeight(): number {
-            return SCREEN_HEIGHT * SCREEN_ROW_COUNT;
-        },
-
-        canvasStyleWidth(): number {
-            return SCREEN_WIDTH * SCREEN_COL_COUNT;
-        },
-    },
-
-    watch: {
-        lastModified() {
-            this.repaint();
-        },
-
-        currentScreen() {
-            this.debouncedRepaint!();
-        }
-    },
-
-    mounted() {
-        this.debouncedRepaint = debounce(this.repaint, 100);
-        this.repaint();
-    },
+function clearArmedScreen() {
+    armedScreenRow.value = armedScreenCol.value = -1;
+    repaint();
 }
+
+function repaint() {
+    const el = canvas.value;
+    if (!el) return;
+    const ctx = el.getContext('2d')!;
+    ctx.save();
+
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, SCREEN_WIDTH * SCREEN_COL_COUNT, SCREEN_HEIGHT * SCREEN_ROW_COUNT);
+
+    const map = props.game.map;
+    for (let row = 0; row < map.rowCount; row++) {
+        for (let col = 0; col < map.colCount; col++) {
+            const screen = map.getScreen(row, col);
+            screen.paint(ctx);
+            screen.paintTopLayer(ctx);
+
+            const currentScreenRow = store.state.currentScreenRow;
+            const currentScreenCol = store.state.currentScreenCol;
+            possiblyOutlineScreen(ctx, row, col, currentScreenRow, currentScreenCol, 'red');
+            possiblyOutlineScreen(ctx, row, col, armedScreenRow.value, armedScreenCol.value, 'blue');
+
+            ctx.translate(SCREEN_WIDTH, 0);
+        }
+        ctx.translate(-SCREEN_WIDTH * map.colCount, SCREEN_HEIGHT);
+    }
+
+    ctx.restore();
+    // console.log('Done repainting');
+}
+
+function mouseEventToScreen(e: MouseEvent) {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const el = canvas.value!;
+    const canvasWidth = el.clientWidth;
+    const canvasHeight = el.clientHeight;
+
+    const virtualScreenWidth = canvasWidth / SCREEN_COL_COUNT;
+    const virtualScreenHeight = canvasHeight / SCREEN_ROW_COUNT;
+
+    const row = Math.floor(y / virtualScreenHeight);
+    const col = Math.floor(x / virtualScreenWidth);
+
+    return { row, col };
+}
+
+function possiblyOutlineScreen(ctx: CanvasRenderingContext2D, row: number, col: number,
+                               targetRow: number, targetCol: number, style: string) {
+    if (row === targetRow && col === targetCol) {
+        ctx.strokeStyle = style;
+        ctx.lineWidth = 10;
+        ctx.strokeRect(0, 0, SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10);
+    }
+}
+
+function updateArmedScreen(e: MouseEvent) {
+    const { row, col } = mouseEventToScreen(e);
+    if (row !== armedScreenRow.value || col !== armedScreenCol.value) {
+        armedScreenRow.value = row;
+        armedScreenCol.value = col;
+        repaint();
+    }
+}
+
+function updateSelectedScreen(e: MouseEvent) {
+    const { row, col } = mouseEventToScreen(e);
+    store.commit('setCurrentScreen', { row, col });
+}
+
+watch(() => props.lastModified, () => {
+    repaint();
+});
+
+watch(currentScreen, () => {
+    debouncedRepaint.value && debouncedRepaint.value();
+});
+
+onMounted(() => {
+    debouncedRepaint.value = debounce(repaint, 100);
+    repaint();
+});
 </script>
 
 <style lang="scss" scoped>

--- a/src/editor/nav-bar.test.ts
+++ b/src/editor/nav-bar.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createVuetify } from 'vuetify/framework';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import type { Component, Plugin } from 'vue';
+import { render, screen } from '@testing-library/vue';
+import NavBar from '@/editor/nav-bar.vue';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => {
+    const mockCommit = vi.fn();
+    return {
+        useStore: () => ({
+            commit: mockCommit
+        }),
+    };
+});
+
+vi.mock('vuex', () => ({
+    useStore: mocks.useStore,
+}));
+
+describe('NavBar', () => {
+    let vuetify: Plugin;
+    let user: UserEvent;
+
+    beforeEach(() => {
+        vuetify = createVuetify({
+            components,
+            directives,
+        });
+        const vuetifyAppWrapper = {
+            template: '<v-app><NavBar/></v-app>',
+            components: { NavBar: NavBar as Component },
+        };
+        render(vuetifyAppWrapper, {
+            props: {},
+            global: {
+                plugins: [vuetify]
+            },
+        });
+        user = userEvent.setup();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+    });
+
+    it('renders app bar and title', () => {
+        expect(screen.getByText('Zelda Map Creator')).toBeInTheDocument();
+    });
+
+    it('updates the map when the level dropdown is updated', async() => {
+        const select: HTMLSelectElement = screen.getByText('Overworld');
+        await user.click(select);
+        await user.click(screen.getByText('Level 1'));
+        expect(mocks.useStore().commit).toHaveBeenCalledExactlyOnceWith('setMap', 'level1');
+    });
+});

--- a/src/editor/nav-bar.vue
+++ b/src/editor/nav-bar.vue
@@ -33,62 +33,40 @@
     </v-app-bar>
 </template>
 
-<script lang="ts">
-export default {
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useStore } from 'vuex';
 
-    name: 'NavBar',
+const selectedMap = ref<string | null>(null);
+const maps = ref<{ title: string, value: string }[]>([]);
+const select = ref();
+const store = useStore();
 
-    data() {
-        return {
-            selectedMap: null, // string | null
-            maps: [], // any[]
-        };
-    },
-
-    methods: {
-        focusCanvas() {
-            // // Cheap way to broadcast an event to other components
-            // // Find a better way to do this, but the interested canvas is a distant sibling.
-            // this.$root.$emit('focusCanvas');
-        },
-
-        onSelectedMapChanged(newValue: string) {
-            // // Cheap way to broadcast an event to other components
-            // // Find a better way to do this, but the interested canvas is a distant sibling.
-            (this.$refs.select as HTMLSelectElement).blur();
-            // this.$root.$emit('focusCanvas');
-
-            this.$store.commit('setMap', newValue);
-        },
-
-        /**
-         * Prevents the select from gaining focus.  If we don't do this, the
-         * user pressing the up or down arrow keys will also navigate through
-         * the select's options, besides just changing screens in the nmap
-         * editor.
-         *
-         * @param e The focus event.
-         */
-        preventFocus(e: FocusEvent) {
-            e.preventDefault();
-            if (e.relatedTarget) {
-                // Revert focus back to previous blurring element
-                (e.relatedTarget as HTMLElement).focus();
-            }
-            else {
-                // No previous focus target, blur instead
-                (e.currentTarget as HTMLElement).blur();
-            }
-        },
-    },
-
-    mounted() {
-        this.maps.push({ title: 'Overworld', value: 'overworld' });
-        for (let i = 1; i <= 1; i++) {
-            this.maps.push({ title: `Level ${i}`, value: `level${i}` });
-        }
-
-        this.selectedMap = 'overworld'; // TODO: Get the real current map
-    },
+function focusCanvas() {
+    // // Cheap way to broadcast an event to other components
+    // // Find a better way to do this, but the interested canvas is a distant sibling.
+    // getCurrentInstance()?.proxy?.$root.$emit('focusCanvas');
 }
+
+function onSelectedMapChanged(newValue: string) {
+    (select.value as any)?.blur();
+    store.commit('setMap', newValue);
+}
+
+function preventFocus(e: FocusEvent) {
+    e.preventDefault();
+    if (e.relatedTarget) {
+        (e.relatedTarget as HTMLElement).focus();
+    } else {
+        (e.currentTarget as HTMLElement).blur();
+    }
+}
+
+onMounted(() => {
+    maps.value.push({ title: 'Overworld', value: 'overworld' });
+    for (let i = 1; i <= 1; i++) {
+        maps.value.push({ title: `Level ${i}`, value: `level${i}` });
+    }
+    selectedMap.value = 'overworld'; // TODO: Get the real current map
+});
 </script>

--- a/src/editor/screen-misc.test.ts
+++ b/src/editor/screen-misc.test.ts
@@ -1,0 +1,93 @@
+// src/editor/screen-misc.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import ScreenMisc from './screen-misc.vue';
+import { createVuetify } from 'vuetify';
+import { Screen } from '@/Screen';
+import { nextTick } from 'vue';
+
+const createMockScreen = (music: string): Screen => ({
+    music,
+} as unknown as Screen);
+const mocks = vi.hoisted(() => {
+    const mockCommit = vi.fn();
+    return {
+        useStore: () => ({
+            state: {
+                currentScreen: createMockScreen('overworldMusic'),
+            },
+            commit: mockCommit
+        }),
+    };
+});
+
+vi.mock('vuex', () => ({
+    useStore: mocks.useStore,
+}));
+
+const vuetify = createVuetify();
+
+describe('ScreenMisc', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('sets initial music value from screen', async() => {
+        render(ScreenMisc, {
+            props: {
+                screen: createMockScreen('overworldMusic'),
+            },
+            global: {
+                plugins: [vuetify],
+            },
+        });
+
+        await nextTick();
+        const select: HTMLSelectElement = screen.getByLabelText('Music');
+        expect(select.value).toEqual('Overworld');
+    });
+
+    it('commits setCurrentScreenMusic when music changes', async() => {
+        render(ScreenMisc, {
+            global: {
+                plugins: [vuetify],
+            },
+        });
+
+        const select: HTMLSelectElement = screen.getByLabelText('Music');
+        await userEvent.click(select);
+        const option = screen.getByText('Labyrinth');
+        await userEvent.click(option);
+        expect(mocks.useStore().commit).toHaveBeenCalledWith('setCurrentScreenMusic', 'labyrinthMusic');
+    });
+
+    // TODO: Enable this when this component removes the computed/prop double-up of screen
+    /* eslint-disable  @typescript-eslint/unbound-method */
+    it.skip('updates music when currentScreen changes', async() => {
+        const { rerender } = render(ScreenMisc, {
+            props: {
+                screen: createMockScreen('overworldMusic'),
+            },
+            global: {
+                plugins: [vuetify],
+            },
+        });
+
+
+        // Simulate screen change
+        const newScreen: Screen = { music: 'labyrinthMusic' } as unknown as Screen;
+
+        await rerender({
+            screen: newScreen,
+        });
+
+        await waitFor(() => {
+            const select: HTMLSelectElement = screen.getByLabelText('Music');
+            expect(select.value).toEqual('Labyrinth');
+        });
+    });
+    /* eslint-enable  @typescript-eslint/unbound-method */
+});

--- a/src/editor/screen-misc.vue
+++ b/src/editor/screen-misc.vue
@@ -1,55 +1,45 @@
 <template>
     <div>
         <div>
-            <label>Music</label>
-            <v-select :items="songs" v-model="music" @update:modelValue="onMusicChanged"/>
+            <v-select label="Music" :items="songs" v-model="music" @update:modelValue="onMusicChanged"/>
         </div>
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue';
+import { useStore } from 'vuex';
 import { Screen } from '@/Screen';
 
-export default {
+const store = useStore();
 
-    name: 'ScreenMisc',
+const songs = [
+    { title: '(default)', value: null },
+    { title: 'No music', value: 'none' },
+    { title: 'Overworld', value: 'overworldMusic' },
+    { title: 'Labyrinth', value: 'labyrinthMusic' }
+];
 
-    data() {
-        return {
-            songs: [
-                {title: '(default)', value: null},
-                {title: 'No music', value: 'none'},
-                {title: 'Overworld', value: 'overworldMusic'},
-                {title: 'Labyrinth', value: 'labyrinthMusic'}
-            ],
-            music: null,//this.songs[0].value,
-        };
-    },
+defineProps<{
+    screen: Screen,
+}>();
 
-    mounted() {
-        // Kick in the pants for initial value
-        this.music = this.screen?.music ?? null;
-    },
 
-    methods: {
-        onMusicChanged(newValue: string) {
-            this.$store.commit('setCurrentScreenMusic', newValue);
-        },
-    },
+const music = ref<string | null>(null);
 
-    watch: {
-        screen: function(newScreen: Screen) {
-            // default to null so we render properly for undefined
-            this.music = newScreen?.music ?? null;
-        },
-    },
+const screen = computed<Screen | null>(() => store.state.currentScreen);
 
-    computed: {
-        screen() {
-            return this.$store.state.currentScreen;
-        },
-    },
+function onMusicChanged(newValue: string | null) {
+    store.commit('setCurrentScreenMusic', newValue);
 }
+
+onMounted(() => {
+    music.value = screen.value?.music ?? null;
+});
+
+watch(screen, (newScreen) => {
+    music.value = newScreen?.music ?? null;
+});
 </script>
 
 <style lang="scss">

--- a/src/editor/store.test.ts
+++ b/src/editor/store.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import store from './store';
+import { Screen } from '@/Screen';
+import { ZeldaGame } from '@/ZeldaGame';
+import { Position } from '@/Position';
+
+const mockScreen = {
+    music: 'fakeMusic',
+};
+
+const mockMap = {
+    currentScreen: mockScreen,
+    currentScreenRow: 1,
+    currentScreenCol: 1,
+    rowCount: 3,
+    colCount: 3,
+    getScreen: vi.fn(() => mockScreen),
+    setCurrentScreen: vi.fn(),
+};
+
+const mockGame = {
+    map: mockMap,
+    setMap: vi.fn(),
+};
+
+describe('store', () => {
+    beforeEach(() => {
+        store.replaceState({
+            game: mockGame as unknown as ZeldaGame,
+            currentScreen: mockMap.currentScreen as unknown as Screen,
+            currentScreenRow: -1,
+            currentScreenCol: -1,
+            lastModified: 0
+        });
+    });
+
+    it('setCurrentScreen updates screen and coordinates', () => {
+        const pair = { row: 2, col: 3 };
+        store.commit('setCurrentScreen', pair);
+        expect(mockMap.setCurrentScreen).toHaveBeenCalledExactlyOnceWith(2, 3);
+        expect(store.state.currentScreenRow).toBe(2);
+        expect(store.state.currentScreenCol).toBe(3);
+    });
+
+    it('setCurrentScreenMusic sets music on currentScreen', () => {
+        expect(store.state.currentScreen?.music).not.toEqual('overworldMusic');
+        store.commit('setCurrentScreenMusic', 'overworldMusic');
+        expect(store.state.currentScreen?.music).toEqual('overworldMusic');
+    });
+
+    it('setMap updates map and coordinates', () => {
+        store.commit('setMap', 'level1');
+        expect(mockGame.setMap).toHaveBeenCalledWith(
+            'level1',
+            expect.any(Position),
+            expect.any(Position)
+        );
+    });
+
+    it('updateLastModified sets lastModified to current time', () => {
+        const before = store.state.lastModified;
+        store.commit('updateLastModified');
+        expect(store.state.lastModified).toBeGreaterThanOrEqual(before);
+    });
+});

--- a/src/editor/tile-palette.test.ts
+++ b/src/editor/tile-palette.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, RenderResult, screen } from '@testing-library/vue';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import TilePalette from './tile-palette.vue';
+import { createVuetify } from 'vuetify';
+import { nextTick } from 'vue';
+import { ZeldaGame } from '@/ZeldaGame';
+import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
+import { Tileset } from '@/Tileset';
+
+const vuetify = createVuetify();
+
+function createTilesetMock(): Tileset {
+    return {
+        getName: () => 'tileset1',
+        colCount: 2,
+        rowCount: 2,
+    } as unknown as Tileset;
+}
+
+const gtpImageDraw = vi.fn();
+function createMockSpriteSheet(): SpriteSheet {
+    return {
+        gtpImage: {
+            draw: gtpImageDraw,
+        },
+    } as unknown as SpriteSheet;
+}
+
+function createMockGame(spriteSheet: SpriteSheet): ZeldaGame {
+    return {
+        assets: {
+            get: vi.fn(() => spriteSheet),
+        },
+    } as unknown as ZeldaGame;
+}
+
+describe('TilePalette', () => {
+    let mockSpriteSheet: SpriteSheet;
+    let mockGame: ZeldaGame;
+    let wrapper: RenderResult;
+    let user: UserEvent;
+
+    beforeEach(() => {
+        mockSpriteSheet = createMockSpriteSheet();
+        mockGame = createMockGame(mockSpriteSheet);
+        vi.useFakeTimers();
+        user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        wrapper = render(TilePalette, {
+            global: {
+                plugins: [vuetify],
+            },
+            props: {
+                game: mockGame,
+                tileset: createTilesetMock(),
+                selectedTileIndex: 1,
+            },
+        });
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
+    });
+
+    it('renders after a delay on mount', async() => {
+        expect(gtpImageDraw).not.toHaveBeenCalledOnce();
+        vi.advanceTimersByTime(300);
+        await nextTick();
+        expect(gtpImageDraw).toHaveBeenCalledOnce();
+    });
+
+    it('emits tileSelected and repaints on canvas click', async() => {
+        const canvas = screen.getByLabelText('Tile palette');
+        await user.click(canvas);
+        expect(wrapper.emitted()).toHaveProperty('tileSelected');
+    });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+// Vuetify requires some extra mocking that jsdom doesn't provide
+vi.stubGlobal('visualViewport', new EventTarget());
+
+vi.stubGlobal('ResizeObserver', vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+})));

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,4 @@
 import {defineConfig} from 'vite'
-import path from 'path';
 import {resolve} from 'path';
 import vue from '@vitejs/plugin-vue';
 import vuetify from 'vite-plugin-vuetify';
@@ -7,7 +6,7 @@ import vuetify from 'vite-plugin-vuetify';
 export default defineConfig({
     resolve: {
         alias: {
-            "@": path.resolve(__dirname, "./src/"),
+            "@": resolve(__dirname, "./src/"),
         },
     },
     build: {
@@ -27,5 +26,6 @@ export default defineConfig({
         deps: {
             inline: ['vuetify'],
         },
+        setupFiles: [ resolve(__dirname, './src/setupTests.ts') ],
     },
 });


### PR DESCRIPTION
Update a couple of components to use the composition API. Write unit tests for them first to ensure no regressions when migrating from the options API to the composition API. This brings the added benefits of improved test coverage **and** adding some dev dependencies required for testing UI apps that use canvas, etc.