### PR TITLE
Split CI actions into separate workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Build
+name: Lint
 
 on:
   push:
@@ -16,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 22.x, 24.x ]
+        node-version: [ 22.x ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,9 +26,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - name: Build
-      run: npm run build
-    - name: Generate documentation
-      run: npm run doc
-    - name: Run tests
-      run: npm run test
+    - name: Lint
+      run: npm run lint

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,4 +1,3 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Typecheck

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -1,7 +1,6 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Build
+name: Documentation
 
 on:
   push:
@@ -16,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 22.x, 24.x ]
+        node-version: [ 22.x ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,9 +26,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - name: Build
-      run: npm run build
     - name: Generate documentation
       run: npm run doc
-    - name: Run tests
-      run: npm run test

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
       - name: Run tests
         run: npm run test
       - name: Codecov


### PR DESCRIPTION
Split up the build workflow into separate workflows per task (build, lint, doc) to get better visibility into what steps are failing when, and speed things up just a tiny bit.