### PR TITLE
Rename some GitHub workflow jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  lint:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  documentation:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Accidentally named the lint and typedoc jobs `build` due a copy-paste error.