### PR TITLE
Remove browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,0 @@
-> 1%
-last 2 versions


### PR DESCRIPTION
This is no longer used since vite uses esbuild, which doesn't read `.browerslistrc`.