### PR TITLE
Fix #91: yellow rupees should blink

### DIFF
--- a/src/item/AbstractItem.ts
+++ b/src/item/AbstractItem.ts
@@ -1,8 +1,31 @@
 import { Actor } from '@/Actor';
+import { ZeldaGame } from '@/ZeldaGame';
+
+const NEW_FRAME_COUNT = 75; // 1.25 seconds
 
 /**
  * A base class for items that Link can pick up.
  */
 export abstract class AbstractItem extends Actor {
+    // TODO: Convert to millis once millis are passed to update()
+    protected visibleFrameCount: number;
+    protected blinksWhenNew: boolean;
 
+    constructor(game: ZeldaGame) {
+        super(game);
+        this.visibleFrameCount = 0;
+        this.blinksWhenNew = true;
+    }
+
+    override paint(ctx: CanvasRenderingContext2D) {
+        if (this.blinksWhenNew && this.visibleFrameCount > NEW_FRAME_COUNT || this.visibleFrameCount % 8 < 4) {
+            this.paintImpl(ctx);
+        }
+    }
+
+    abstract paintImpl(ctx: CanvasRenderingContext2D): void;
+
+    update() {
+        this.visibleFrameCount++;
+    }
 }

--- a/src/item/Heart.ts
+++ b/src/item/Heart.ts
@@ -27,12 +27,9 @@ export class Heart extends AbstractItem {
         return false;
     }
 
-    paint(ctx: CanvasRenderingContext2D) {
-        const imageName: string = this.game.playTime % 1000 < 500 ? 'fullHeart' : 'blueHeart';
+    override paintImpl(ctx: CanvasRenderingContext2D) {
+        const imageName: string = this.visibleFrameCount % 16 >= 8 ? 'fullHeart' : 'blueHeart';
         const image: Image = this.game.assets.get(`treasures.${imageName}`);
         image.draw(ctx, this.x, this.y);
-    }
-
-    update() {
     }
 }

--- a/src/item/Rupee.ts
+++ b/src/item/Rupee.ts
@@ -47,10 +47,14 @@ export class Rupee extends AbstractItem {
         return this.rupeeCount;
     }
 
-    paint(ctx: CanvasRenderingContext2D): void {
-        this.image.draw(ctx, this.x, this.y);
-    }
+    override paintImpl(ctx: CanvasRenderingContext2D): void {
+        let image = this.image;
 
-    update(): void {
+        // Only the yellow rupee blinks
+        if (this.type === 'yellow' && this.visibleFrameCount % 16 >= 8) {
+            image = this.game.assets.get('treasures.blueRupee');
+        }
+
+        image.draw(ctx, this.x, this.y);
     }
 }


### PR DESCRIPTION
Yellow rupees should blink (alternate between blue and yellow). For some reason however, blue rupees don't blink (probably not another color to alternate to on the NES?).

In addition, most items (currently hearts and rupees should blink between visible/invisible rapidly when initially dropped, to draw attention to them.