### PR TITLE
Fix #56: bombs damage enemies

### DIFF
--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -1,5 +1,5 @@
 import { Direction } from './Direction';
-import { TILE_HEIGHT, TILE_WIDTH } from './Constants';
+import { ENEMY_HITBOX_STYLE, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { ZeldaGame } from './ZeldaGame';
 import { Position } from './Position';
 import { Rectangle } from 'gtp';
@@ -64,7 +64,7 @@ export abstract class Actor {
      * @return The style to use.
      */
     getHitBoxStyle(): string {
-        return 'red';
+        return ENEMY_HITBOX_STYLE;
     }
 
     /**

--- a/src/Bomb.test.ts
+++ b/src/Bomb.test.ts
@@ -5,6 +5,7 @@ import { Map } from './Map';
 import { ZeldaGame } from './ZeldaGame';
 import { Octorok } from './enemy/Octorok';
 import Image from 'gtp/lib/gtp/Image';
+import { HERO_HITBOX_STYLE } from '@/Constants';
 
 const mockImage = {
     draw: vi.fn(),
@@ -76,6 +77,12 @@ describe('Bomb', () => {
         it('always returns false', () => {
             const other = new Octorok(game);
             expect(bomb.collidedWith(other)).toEqual(false);
+        });
+    });
+
+    describe('getHitBoxStyle()', () => {
+        it('returns the expected string', () => {
+            expect(bomb.getHitBoxStyle()).toEqual(HERO_HITBOX_STYLE);
         });
     });
 

--- a/src/Bomb.ts
+++ b/src/Bomb.ts
@@ -4,6 +4,7 @@ import { Link } from './Link';
 import Rectangle from 'gtp/lib/gtp/Rectangle';
 import Image from 'gtp/lib/gtp/Image';
 import { BombSmoke } from '@/BombSmoke';
+import { HERO_HITBOX_STYLE } from '@/Constants';
 
 /**
  * A bomb Link has dropped, waiting to explode.
@@ -55,7 +56,10 @@ export class Bomb extends Actor {
         game.audio.playSound('bombBlow');
 
         game.map.currentScreen.addActor(new BombSmoke(this.game, this.dir, this.x, this.y));
-        // TODO: Damage enemies somehow
+    }
+
+    override getHitBoxStyle(): string {
+        return HERO_HITBOX_STYLE;
     }
 
     paint(ctx: CanvasRenderingContext2D) {

--- a/src/BombSmoke.test.ts
+++ b/src/BombSmoke.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HERO_HITBOX_STYLE } from '@/Constants';
+import { ZeldaGame } from '@/ZeldaGame';
+import { Link } from '@/Link';
+import Image from 'gtp/lib/gtp/Image';
+import { BombSmoke } from '@/BombSmoke';
+import { Octorok } from '@/enemy/Octorok';
+import { Direction } from '@/Direction';
+
+const mockImage = {
+    drawByIndex: vi.fn(),
+};
+
+describe('BombSmoke', () => {
+    let game: ZeldaGame;
+    let bombSmoke: BombSmoke;
+
+    beforeEach(() => {
+        game = new ZeldaGame();
+        game.link = new Link(game);
+        game.assets.set('link', mockImage as unknown as Image);
+        bombSmoke = new BombSmoke(game, 'UP', 0, 0);
+    });
+
+    describe('canDamageEnemies', () => {
+        it('returns true until the expected frame count passes', () => {
+            for (let frame = 1; frame <= 30; frame++) {
+                bombSmoke.update();
+                expect(bombSmoke.canDamageEnemies()).toEqual(true);
+            }
+
+            bombSmoke.update();
+            expect(bombSmoke.canDamageEnemies()).toEqual(false);
+        });
+    });
+
+    describe('collidedWith()', () => {
+        it('always returns false', () => {
+            const octorock = new Octorok(game);
+            expect(bombSmoke.collidedWith(octorock)).equals(false);
+        });
+    });
+
+    describe('getHitBoxStyle()', () => {
+        it('returns the expected string', () => {
+            expect(bombSmoke.getHitBoxStyle()).toEqual(HERO_HITBOX_STYLE);
+        });
+    });
+
+    describe('paint()', () => {
+        let ctx: CanvasRenderingContext2D;
+
+        beforeEach(() => {
+            ctx = game.getRenderingContext();
+        });
+
+        const directions: Direction[] = [ 'DOWN', 'LEFT', 'UP', 'RIGHT' ];
+        directions.forEach((dir) => {
+            it(`does not error painting ${dir}`, () => {
+                bombSmoke.dir = dir;
+                expect(() => {
+                    bombSmoke.paint(ctx);
+                }).not.toThrow();
+            });
+        });
+    });
+
+    describe('update()', () => {
+        it('sets the actor to "done" after 30 frames', () => {
+            for (let frame = 0; frame < 29; frame++) {
+                bombSmoke.update();
+                expect(bombSmoke.done).toEqual(false);
+            }
+
+            bombSmoke.update();
+            expect(bombSmoke.done).toEqual(true);
+        });
+    });
+});

--- a/src/BombSmoke.ts
+++ b/src/BombSmoke.ts
@@ -2,6 +2,7 @@ import { Actor } from '@/Actor';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Direction } from '@/Direction';
 import { Rectangle, SpriteSheet } from 'gtp';
+import { HERO_HITBOX_STYLE, TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
 
 interface FrameInfo {
     dir: Direction;
@@ -95,6 +96,8 @@ dirToFrameInfos.set('DOWN', leftFrameInfos);
 dirToFrameInfos.set('RIGHT', rightFrameInfos);
 dirToFrameInfos.set('UP', rightFrameInfos);
 
+const MAX_DAMAGING_FRAME = 30;
+
 /**
  * An actor that can't collide with any other actors. It's essentially just a
  * visual effect that's a collection of animations.
@@ -106,11 +109,19 @@ export class BombSmoke extends Actor {
         super(game);
         this.dir = dir;
         this.frame = 0;
-        this.hitBox = new Rectangle();
+        this.hitBox = new Rectangle(x, y, TILE_WIDTH, TILE_HEIGHT);
+    }
+
+    canDamageEnemies(): boolean {
+        return this.frame <= MAX_DAMAGING_FRAME;
     }
 
     override collidedWith(other: Actor): boolean {
         return false;
+    }
+
+    override getHitBoxStyle(): string {
+        return HERO_HITBOX_STYLE;
     }
 
     override paint(ctx: CanvasRenderingContext2D) {
@@ -125,6 +136,8 @@ export class BombSmoke extends Actor {
                 this.paintSmokeRightOrientation(ctx, frameInfo.index);
             }
         }
+
+        this.possiblyPaintHitBox(ctx);
     }
 
     private paintSmokeLeftOrientation(ctx: CanvasRenderingContext2D, index: number) {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -49,3 +49,6 @@ export const WALKABILITY_OVERWORLD: number[] = [
     1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
     1, 1, 0, 0, 0, 0, 1, 0, 0, 0,
 ];
+
+export const ENEMY_HITBOX_STYLE = 'red';
+export const HERO_HITBOX_STYLE = 'blue';

--- a/src/Link.test.ts
+++ b/src/Link.test.ts
@@ -7,7 +7,7 @@ import { AudioSystem, InputManager, Keys, SpriteSheet } from 'gtp';
 import { Projectile } from '@/Projectile';
 import { opposite } from '@/Direction';
 import { AnimationListener } from '@/AnimationListener';
-import { SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
+import { HERO_HITBOX_STYLE, SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
 import { MainGameState } from '@/MainGameState';
 import { Animation } from '@/Animation';
 import { createAnimation } from '@/test-utils';
@@ -296,6 +296,12 @@ describe('Link', () => {
             expect(link.getShouldThrowSword()).toEqual(true);
             link.incHealth(-1);
             expect(link.getShouldThrowSword()).toEqual(true);
+        });
+    });
+
+    describe('getHitBoxStyle()', () => {
+        it('returns the expected string', () => {
+            expect(link.getHitBoxStyle()).toEqual(HERO_HITBOX_STYLE);
         });
     });
 

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -4,7 +4,7 @@ import { Animation } from './Animation';
 import { Enemy } from './enemy/Enemy';
 import { AnimationListener } from './AnimationListener';
 import { opposite, ordinal } from './Direction';
-import { SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from './Constants';
+import { HERO_HITBOX_STYLE, SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { Sword } from './Sword';
 import { MainGameState } from './MainGameState';
 import { ZeldaGame } from './ZeldaGame';
@@ -127,6 +127,10 @@ export class Link extends Character {
 
     getHealth(): number {
         return this.health;
+    }
+
+    override getHitBoxStyle(): string {
+        return HERO_HITBOX_STYLE;
     }
 
     getMaxHealth(): number {

--- a/src/Projectile.test.ts
+++ b/src/Projectile.test.ts
@@ -6,6 +6,7 @@ import { ZeldaGame } from './ZeldaGame';
 import { Octorok } from '@/enemy/Octorok';
 import { Animation } from '@/Animation';
 import { createAnimation } from '@/test-utils';
+import { ENEMY_HITBOX_STYLE, HERO_HITBOX_STYLE } from '@/Constants';
 
 const mockDrawByIndex = vi.fn();
 
@@ -100,6 +101,19 @@ describe('Projectile', () => {
             expect(p.getDamage()).toEqual(1);
             p.setDamage(5);
             expect(p.getDamage()).toEqual(5);
+        });
+    });
+
+    describe('getHitBoxStyle()', () => {
+        it('defaults to red', () => {
+            const p = Projectile.create(game, null, 'enemies', 0, 0, 0, 0, 'LEFT');
+            expect(p.getHitBoxStyle()).toEqual(ENEMY_HITBOX_STYLE);
+        });
+
+        it('returns blue if targeting enemies', () => {
+            const p = Projectile.create(game, null, 'enemies', 0, 0, 0, 0, 'LEFT');
+            p.setTarget('enemy');
+            expect(p.getHitBoxStyle()).toEqual(HERO_HITBOX_STYLE);
         });
     });
 

--- a/src/Projectile.ts
+++ b/src/Projectile.ts
@@ -1,4 +1,4 @@
-import { SCREEN_HEIGHT, SCREEN_WIDTH, TILE_HEIGHT, TILE_WIDTH } from './Constants';
+import { HERO_HITBOX_STYLE, SCREEN_HEIGHT, SCREEN_WIDTH, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { Direction } from './Direction';
 import { Actor } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
@@ -87,6 +87,13 @@ export class Projectile extends Actor {
 
     getDamage(): number {
         return this.damage;
+    }
+
+    override getHitBoxStyle(): string {
+        if (this.target === 'enemy') {
+            return HERO_HITBOX_STYLE;
+        }
+        return super.getHitBoxStyle();
     }
 
     getSource(): Actor | null {

--- a/src/Sword.ts
+++ b/src/Sword.ts
@@ -5,6 +5,7 @@ import { ZeldaGame } from './ZeldaGame';
 import { Rectangle, SpriteSheet } from 'gtp';
 import { AnimationProjectileRenderInfo, Projectile } from '@/Projectile';
 import { Animation } from '@/Animation';
+import { HERO_HITBOX_STYLE } from '@/Constants';
 
 /**
  * Initial frames, the sword isn't rendered as swinging.
@@ -170,7 +171,7 @@ export class Sword extends Actor {
     }
 
     override getHitBoxStyle(): string {
-        return 'blue';
+        return HERO_HITBOX_STYLE;
     }
 
     paint(ctx: CanvasRenderingContext2D) {

--- a/src/enemy/Enemy.ts
+++ b/src/enemy/Enemy.ts
@@ -8,6 +8,7 @@ import { ZeldaGame } from '@/ZeldaGame';
 import { SpriteSheet } from 'gtp';
 import { AbstractItem } from '@/item/AbstractItem';
 import { Projectile } from '@/Projectile';
+import { BombSmoke } from '@/BombSmoke';
 
 const STEP_TIMER_MAX = 10;
 
@@ -129,6 +130,7 @@ export abstract class Enemy extends Character {
 
     private takesDamageFrom(other: Actor): boolean {
         return other instanceof Sword ||
+            other instanceof BombSmoke && other.canDamageEnemies() ||
             other instanceof Projectile && other.getSource() !== this && other.targets('enemy');
     }
 


### PR DESCRIPTION
Make enemies damaged by bombs exploding.

We don't have the decompiled code here, so this PR will assume:

1. A 1-tile blast radius; i.e., collision detection will be against the "center" of the explosion
2. It will last for 30 frames / 0.5 seconds

We can tweak this logic if we find the actual explosion logic later.