### PR TITLE
feat: Projectiles bounce off Link's shield

### DIFF
--- a/src/Animation.test.ts
+++ b/src/Animation.test.ts
@@ -79,6 +79,18 @@ describe('Animation', () => {
         });
     });
 
+    describe('getCurrentFrameImage()', () => {
+        it('returns the current frame image', () => {
+            animation.update(); // First call initializes
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+            expect(animation.getCurrentFrameImage().index).toEqual(0);
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(101);
+            animation.update();
+            expect(animation.getCurrentFrameImage().index).toEqual(1);
+        });
+    });
+
     describe('height and width', () => {
         it('returns correct cell size when not done', () => {
             expect(animation.height).toEqual(mockSpriteSheet.cellH);

--- a/src/Animation.ts
+++ b/src/Animation.ts
@@ -1,15 +1,6 @@
 import { AnimationListener } from './AnimationListener';
 import { ZeldaGame } from './ZeldaGame';
-import { SpriteSheet } from 'gtp';
-
-/**
- * Structure representing a single frame in an <code>Animation</code>.
- */
-export interface SpriteSheetAndIndex {
-
-    sheet: SpriteSheet;
-    index: number;
-}
+import { SpriteSheetAndIndex } from '@/SpriteSheetAndIndex';
 
 /**
  * A frame in an animation.
@@ -61,6 +52,10 @@ export class Animation {
                 listener.animationFrameUpdate.call(listener.scope ?? listener, this);
             }
         });
+    }
+
+    getCurrentFrameImage(): SpriteSheetAndIndex {
+        return this.frames[this.curFrame].sheetAndIndex;
     }
 
     get frame(): number {

--- a/src/Animations.test.ts
+++ b/src/Animations.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    createEnemyDiesAnimation,
+    createLinkDyingAnimation,
+    createReflectedProjectileAnimation,
+    createStairsDownAnimation, createStairsUpAnimation,
+} from '@/Animations';
+import { Link } from '@/Link';
+import { ZeldaGame } from '@/ZeldaGame';
+import { Map } from '@/Map';
+import { AudioSystem } from 'gtp';
+import { Octorok } from '@/enemy/Octorok';
+import { Projectile } from '@/Projectile';
+import { Direction } from '@/Direction';
+
+const mockPlayMusic = vi.fn();
+const mockPlaySound = vi.fn();
+const mockAudio = {
+    playMusic: mockPlayMusic,
+    playSound: mockPlaySound,
+};
+
+const mockMap = {
+    currentScreen: screen,
+};
+
+const mockSpriteSheet = {
+    drawByIndex: vi.fn(),
+};
+
+describe('Animations', () => {
+    let link: Link;
+    let game: ZeldaGame;
+
+    beforeEach(() => {
+        game = new ZeldaGame();
+        game.map = mockMap as unknown as Map;
+        game.audio = mockAudio as unknown as AudioSystem;
+        game.assets.set('enemyDies', mockSpriteSheet);
+        game.assets.set('enemies', mockSpriteSheet);
+        game.assets.set('link', mockSpriteSheet);
+        link = new Link(game);
+        game.link = link;
+    });
+
+    describe('createEnemyDiesAnimation()', () => {
+        let enemy: Octorok;
+
+        beforeEach(() => {
+            enemy = new Octorok(game);
+        });
+
+        it('works if no listener is provided', () => {
+            expect(() => {
+                createEnemyDiesAnimation(game, enemy, 0, 0);
+            }).not.toThrow();
+        });
+
+        it('calls the completed callback if provided', () => {
+            const listener = {
+                animationFrameUpdate: vi.fn(),
+                animationCompleted: vi.fn(),
+            };
+            const anim = createEnemyDiesAnimation(game, enemy, 0, 0, listener);
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+            anim.update(); // First call initializes
+
+            for (let i = 0; i < 11; i++) {
+                vi.spyOn(game, 'playTime', 'get').mockReturnValue((i + 1) * 31);
+                anim.update();
+                expect(listener.animationFrameUpdate).toHaveBeenCalledTimes(i + 1);
+            }
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(12 * 31);
+            anim.update();
+            expect(listener.animationCompleted).toHaveBeenCalledExactlyOnceWith(anim);
+        });
+    });
+
+    describe('createLinkDyingAnimation()', () => {
+        it('works if no listener is provided', () => {
+            expect(() => {
+                createLinkDyingAnimation(game, link, 0, 0);
+            }).not.toThrow();
+        });
+
+        it('calls the completed callback if provided', () => {
+            const listener = {
+                animationFrameUpdate: vi.fn(),
+                animationCompleted: vi.fn(),
+            };
+            const anim = createLinkDyingAnimation(game, link, 0, 0, listener);
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+            anim.update(); // First call initializes
+
+            // 1001ms to cover the longest frame
+            for (let i = 0; i < 32; i++) {
+                vi.spyOn(game, 'playTime', 'get').mockReturnValue((i + 1) * 1001);
+                anim.update();
+                expect(listener.animationFrameUpdate).toHaveBeenCalledTimes(i + 1);
+            }
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(33 * 1001);
+            anim.update();
+            expect(listener.animationCompleted).toHaveBeenCalledExactlyOnceWith(anim);
+        });
+    });
+
+    describe('createReflectedProjectileAnimation()', () => {
+        let enemy: Octorok;
+        let projectile: Projectile;
+
+        beforeEach(() => {
+            enemy = new Octorok(game);
+            projectile = Projectile.create(game, enemy, 'enemies',0, 12, 0, 0, 'UP');
+        });
+
+        const directions: Direction[] = [ 'DOWN', 'LEFT', 'UP', 'RIGHT' ];
+        directions.forEach((dir) => {
+            describe(`for direction ${dir}`, () => {
+                beforeEach(() => {
+                    projectile.dir = dir;
+                });
+
+                it('works if no listener is provided', () => {
+                    expect(() => {
+                        createReflectedProjectileAnimation(game, projectile, 0, 0);
+                    }).not.toThrow();
+                });
+
+                it('calls the completed callback if provided', () => {
+                    const listener = {
+                        animationFrameUpdate: vi.fn(),
+                        animationCompleted: vi.fn(),
+                    };
+                    const anim = createReflectedProjectileAnimation(game, projectile, 0, 0, listener);
+
+                    vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+                    anim.update(); // First call initializes
+
+                    for (let i = 0; i < 14; i++) {
+                        vi.spyOn(game, 'playTime', 'get').mockReturnValue((i + 1) * 31);
+                        anim.update();
+                        expect(listener.animationFrameUpdate).toHaveBeenCalledTimes(i + 1);
+                    }
+
+                    vi.spyOn(game, 'playTime', 'get').mockReturnValue(16 * 31);
+                    anim.update();
+                    expect(listener.animationCompleted).toHaveBeenCalledExactlyOnceWith(anim);
+                });
+            });
+        });
+    });
+
+    describe('createStairsDownAnimation()', () => {
+        it('works if no listener is provided', () => {
+            expect(() => {
+                createStairsDownAnimation(game, link, 0, 0);
+            }).not.toThrow();
+        });
+
+        it('calls the completed callback if provided', () => {
+            const listener = {
+                animationFrameUpdate: vi.fn(),
+                animationCompleted: vi.fn(),
+            };
+            const anim = createStairsDownAnimation(game, link, 0, 0, listener);
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+            anim.update(); // First call initializes
+
+            for (let i = 0; i < 7; i++) {
+                vi.spyOn(game, 'playTime', 'get').mockReturnValue((i + 1) * 121);
+                anim.update();
+                expect(listener.animationFrameUpdate).toHaveBeenCalledTimes(i + 1);
+            }
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(8 * 121);
+            anim.update();
+            expect(listener.animationCompleted).toHaveBeenCalledExactlyOnceWith(anim);
+        });
+    });
+
+    describe('createStairsUpAnimation()', () => {
+        it('works if no listener is provided', () => {
+            expect(() => {
+                createStairsUpAnimation(game, link, 0, 0);
+            }).not.toThrow();
+        });
+
+        it('calls the completed callback if provided', () => {
+            const listener = {
+                animationFrameUpdate: vi.fn(),
+                animationCompleted: vi.fn(),
+            };
+            const anim = createStairsUpAnimation(game, link, 0, 0, listener);
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(0);
+            anim.update(); // First call initializes
+
+            for (let i = 0; i < 7; i++) {
+                vi.spyOn(game, 'playTime', 'get').mockReturnValue((i + 1) * 121);
+                anim.update();
+                expect(listener.animationFrameUpdate).toHaveBeenCalledTimes(i + 1);
+            }
+
+            vi.spyOn(game, 'playTime', 'get').mockReturnValue(8 * 121);
+            anim.update();
+            expect(listener.animationCompleted).toHaveBeenCalledExactlyOnceWith(anim);
+        });
+    });
+});

--- a/src/Link.test.ts
+++ b/src/Link.test.ts
@@ -146,7 +146,7 @@ describe('Link', () => {
             });
         });
 
-        describe('the other entity is an Projectile', () => {
+        describe('the other entity is a Projectile', () => {
             let projectile: Projectile;
 
             beforeEach(() => {
@@ -181,6 +181,12 @@ describe('Link', () => {
                 it('plays the shield sound effect', () => {
                     link.collidedWith(projectile);
                     expect(mockPlaySound).toHaveBeenCalledExactlyOnceWith('shield');
+                });
+
+                it('adds an animation of the reflected projectile', () => {
+                    const addAnimationSpy = vi.spyOn(game, 'addAnimation').mockImplementation(() => {})
+                    link.collidedWith(projectile);
+                    expect(addAnimationSpy).toHaveBeenCalledOnce();
                 });
 
                 it('does not damage Link', () => {

--- a/src/Projectile.test.ts
+++ b/src/Projectile.test.ts
@@ -14,7 +14,7 @@ const mockSpriteSheet = {
     colCount: 8,
     rowCount: 4,
     size: 32,
-    drawByIndex: vi.fn(),
+    drawByIndex: mockDrawByIndex,
 } as unknown as SpriteSheet;
 
 describe('Projectile', () => {
@@ -22,7 +22,7 @@ describe('Projectile', () => {
 
     beforeEach(() => {
         game = new ZeldaGame();
-        game.assets.set('enemies', { drawByIndex: mockDrawByIndex } as unknown as SpriteSheet);
+        game.assets.set('enemies', mockSpriteSheet);
     });
 
     afterEach(() => {
@@ -91,6 +91,28 @@ describe('Projectile', () => {
             it('returns true and sets done if colliding with non-Link', () => {
                 expect(p.collidedWith(new Octorok(game))).toEqual(true);
                 expect(p.done).toEqual(true);
+            });
+        });
+    });
+
+    describe('getBlockedImageSheetAndIndex()', () => {
+        it('returns the expected value for sheet-based projectiles', () => {
+            const p = Projectile.create(game, null, 'enemies', 0, 0, 0, 0, 'LEFT');
+            expect(p.getBlockedImageSheetAndIndex()).toEqual({
+                sheet: mockSpriteSheet,
+                index: 0,
+            });
+        });
+
+        it('returns the expected value for animation-based projectiles', () => {
+            const animRenderInfo: AnimationProjectileRenderInfo = {
+                type: 'animation',
+                animation: createAnimation(game, mockSpriteSheet),
+            };
+            const p = new Projectile(game, animRenderInfo, 0, 0, 'LEFT');
+            expect(p.getBlockedImageSheetAndIndex()).toEqual({
+                sheet: mockSpriteSheet,
+                index: 0,
             });
         });
     });

--- a/src/Projectile.ts
+++ b/src/Projectile.ts
@@ -2,11 +2,12 @@ import { HERO_HITBOX_STYLE, SCREEN_HEIGHT, SCREEN_WIDTH, TILE_HEIGHT, TILE_WIDTH
 import { Direction } from './Direction';
 import { Actor } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
-import { Rectangle } from 'gtp';
+import { Rectangle, SpriteSheet } from 'gtp';
 import { Link } from './Link';
 import { SpriteSheetSpriteLocation } from '@/SpriteSheetSpriteLocation';
 import { Animation } from '@/Animation';
 import { Enemy } from '@/enemy/Enemy';
+import { SpriteSheetAndIndex } from '@/SpriteSheetAndIndex';
 
 export interface SpriteSheetProjectileRenderInfo {
     type: 'spriteSheet',
@@ -72,10 +73,11 @@ export class Projectile extends Actor {
 
     static create(game: ZeldaGame, source: Actor | null, sheetName: string, row: number, col: number, x: number,
         y: number, dir: Direction): Projectile {
+        const sheet: SpriteSheet = game.assets.get(sheetName);
         const sheetInfo: SpriteSheetProjectileRenderInfo = {
             type: 'spriteSheet',
             sheetLocation: {
-                sheet: game.assets.get(sheetName),
+                sheet,
                 row,
                 col,
             },
@@ -83,6 +85,27 @@ export class Projectile extends Actor {
         const projectile = new Projectile(game, sheetInfo, x, y, dir);
         projectile.setSource(source);
         return projectile;
+    }
+
+    /**
+     * If Link's shield can defend against this projectile, this image will "bounce" off of
+     * his shield.
+     */
+    getBlockedImageSheetAndIndex(): SpriteSheetAndIndex {
+        if (this.renderInfo.type === 'animation') {
+            const ssi = this.renderInfo.animation.getCurrentFrameImage();
+            return {
+                sheet: ssi.sheet,
+                index: ssi.index,
+            };
+        }
+
+        // this.renderInfo.type === 'spriteSheet'
+        const sheet = this.renderInfo.sheetLocation.sheet;
+        return {
+            sheet,
+            index: this.renderInfo.sheetLocation.row * sheet.colCount + this.renderInfo.sheetLocation.col,
+        };
     }
 
     getDamage(): number {

--- a/src/SpriteSheetAndIndex.ts
+++ b/src/SpriteSheetAndIndex.ts
@@ -1,0 +1,9 @@
+import { SpriteSheet } from 'gtp';
+
+/**
+ * A tuple representing a specific image in a sprite sheet.
+ */
+export interface SpriteSheetAndIndex {
+    sheet: SpriteSheet;
+    index: number;
+}

--- a/src/ZeldaGame.test.ts
+++ b/src/ZeldaGame.test.ts
@@ -72,8 +72,9 @@ describe('ZeldaGame', () => {
 
     describe('addEnemyDiesAnimation()', () => {
         it('adds an Animation to the animations list', () => {
+            const enemy = new Octorok(game);
             expect(() => {
-                game.addEnemyDiesAnimation(10, 20);
+                game.addEnemyDiesAnimation(enemy);
             }).not.toThrow();
         });
     });
@@ -231,6 +232,29 @@ describe('ZeldaGame', () => {
         it('does not initialize link if initLink is false', () => {
             game.startNewGame(false);
             expect(game.link).toBeDefined();
+        });
+
+        describe('when in editMode', () => {
+            beforeEach(() => {
+                game = new ZeldaGame({
+                    editMode: true,
+                    height: 100,
+                    width: 100,
+                });
+                game.assets.set('overworld', mockSpriteSheet);
+                game.assets.set('overworldData', createMapData({ name: 'overworld' }));
+                game.assets.set('level1Data', createMapData({ name: 'level1' }));
+                game.maps = {
+                    overworld: mockMap,
+                    level1: mockMap,
+                };
+                game.map = mockMap;
+            });
+
+            it('highlights tiles that contain events', () => {
+                game.startNewGame();
+                expect(game.map.showEvents).toEqual(true);
+            })
         });
     });
 

--- a/src/ZeldaGame.ts
+++ b/src/ZeldaGame.ts
@@ -8,6 +8,7 @@ import { ItemDropStrategy } from './item/ItemDropStrategy';
 import { GameArgs } from 'gtp/lib/gtp/Game';
 import { RupeeIncrementor } from '@/RupeeIncrementor';
 import { createEnemyDiesAnimation } from '@/Animations';
+import { Enemy } from '@/enemy/Enemy';
 
 type MapMap = Record<string, Map>;
 
@@ -30,12 +31,14 @@ export class ZeldaGame extends Game {
         this.rupeeIncrementor = new RupeeIncrementor();
     }
 
-    addAnimation(animation: Animation) {
-        this.animations.push(animation);
+    addAnimation(animation: Animation | undefined) {
+        if (animation) {
+            this.animations.push(animation);
+        }
     }
 
-    addEnemyDiesAnimation(x: number, y: number) {
-        this.animations.push(createEnemyDiesAnimation(this, x, y));
+    addEnemyDiesAnimation(source: Enemy) {
+        this.animations.push(createEnemyDiesAnimation(this, source, source.x, source.y));
     }
 
     paintAnimations(ctx: CanvasRenderingContext2D) {

--- a/src/enemy/Enemy.ts
+++ b/src/enemy/Enemy.ts
@@ -47,7 +47,7 @@ export abstract class Enemy extends Character {
             if (--this.health === 0) {
                 this.done = true;
                 game.audio.playSound('enemyDie');
-                game.addEnemyDiesAnimation(this.x, this.y);
+                game.addEnemyDiesAnimation(this);
                 const item: AbstractItem | null = game.itemDropStrategy.itemDropped(this);
                 if (item) {
                     game.map.currentScreen.addActor(item);

--- a/src/enemy/Octorok.test.ts
+++ b/src/enemy/Octorok.test.ts
@@ -1,14 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 import { Link } from '@/Link';
 import { Octorok } from './Octorok';
 import { ZeldaGame } from '@/ZeldaGame';
-import { SpriteSheet } from 'gtp';
+import { AudioSystem, SpriteSheet } from 'gtp';
 import { Map } from '@/Map';
+import { Sword } from '@/Sword';
 
 const mockDrawByIndex = vi.fn();
 const mockSpriteSheet = {
     drawByIndex: mockDrawByIndex,
 } as unknown as SpriteSheet;
+
+const mockImage = {
+    draw: vi.fn(),
+};
 
 describe('Octorok', () => {
     let game: ZeldaGame;
@@ -16,7 +21,9 @@ describe('Octorok', () => {
     beforeEach(() => {
         game = new ZeldaGame();
         game.assets.set('enemies', mockSpriteSheet);
-        game.assets.set('overworld', mockSpriteSheet)
+        game.assets.set('overworld', mockSpriteSheet);
+        game.assets.set('enemyDies', mockSpriteSheet);
+        game.assets.set('treasures.yellowRupee', mockImage);
         game.map = new Map(game, 'overworld', 2, 2);
         game.link = new Link(game);
     });
@@ -36,6 +43,108 @@ describe('Octorok', () => {
             const octorok = new Octorok(game, 'blue');
             expect(octorok.strength).toEqual('blue');
             expect(octorok.enemyName).toEqual('blueOctorok');
+        });
+    });
+
+    describe('collidedWith()', () => {
+        describe("when doesn't take damage from the other actor", () => {
+            let enemy: Octorok;
+
+            beforeEach(() => {
+                enemy = new Octorok(game);
+            });
+
+            it('returns false', () => {
+                const octorok = new Octorok(game);
+                expect(octorok.collidedWith(enemy)).toEqual(false);
+            });
+
+            it('does no damage', () => {
+                const octorok = new Octorok(game);
+                octorok.collidedWith(enemy);
+                expect(octorok.done).toEqual(false);
+            });
+        });
+
+        describe('when does take damage from the other actor', () => {
+            let sword: Sword;
+            let playSoundSpy: MockInstance<AudioSystem['playSound']>;
+
+            beforeEach(() => {
+                sword = new Sword(game);
+                playSoundSpy = vi.spyOn(game.audio, 'playSound').mockImplementation(() => 1);
+            });
+
+            describe('when not already taking damage', () => {
+                describe('when dies with the hit', () => {
+                    it('returns true', () => {
+                        const octorok = new Octorok(game);
+                        expect(octorok.collidedWith(sword)).toEqual(true);
+                    });
+
+                    it('kills the enemy', () => {
+                        const octorok = new Octorok(game);
+                        octorok.collidedWith(sword);
+                        expect(octorok.done).toEqual(true);
+                    });
+
+                    it('plays a sound effect', () => {
+                        const octorok = new Octorok(game);
+                        octorok.collidedWith(sword);
+                        expect(playSoundSpy).toHaveBeenCalledExactlyOnceWith('enemyDie');
+                    });
+
+                    it('adds an animation of the enemy dying', () => {
+                        const animSpy = vi.spyOn(game, 'addEnemyDiesAnimation')
+                            .mockImplementation(() => {});
+                        const octorok = new Octorok(game);
+                        octorok.collidedWith(sword);
+                        expect(animSpy).toHaveBeenCalledExactlyOnceWith(octorok);
+                    });
+                });
+
+                describe('when does not die with the hit', () => {
+                    it('returns false', () => {
+                        const octorok = new Octorok(game, 'blue');
+                        expect(octorok.collidedWith(sword)).toEqual(false);
+                    });
+
+                    it('does not kill the enemy', () => {
+                        const octorok = new Octorok(game, 'blue');
+                        octorok.collidedWith(sword);
+                        expect(octorok.done).toEqual(false);
+                    });
+
+                    it('does not play the "enemy dies" sound effect', () => {
+                        const octorok = new Octorok(game, 'blue');
+                        octorok.collidedWith(sword);
+                        expect(playSoundSpy).not.toHaveBeenLastCalledWith('enemyDie');
+                    });
+
+                    it('adds an animation of the enemy dying', () => {
+                        const animSpy = vi.spyOn(game, 'addEnemyDiesAnimation')
+                            .mockImplementation(() => {});
+                        const octorok = new Octorok(game, 'blue');
+                        octorok.collidedWith(sword);
+                        expect(animSpy).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('when already taking damage', () => {
+                it('returns false', () => {
+                    const octorok = new Octorok(game);
+                    octorok.takingDamage = true;
+                    expect(octorok.collidedWith(sword)).toEqual(false);
+                });
+
+                it('does not kill the octorok', () => {
+                    const octorok = new Octorok(game);
+                    octorok.takingDamage = true;
+                    octorok.collidedWith(sword);
+                    expect(octorok.done).toEqual(false);
+                });
+            })
         });
     });
 


### PR DESCRIPTION
Fixes #92. Make all projectiles bounce off of Link's shield if they hit him "head on."

Note: The game currentl doesn't yet have the Magical Shield, so all projectiles currently bounce off of Link's small/default shield. When the Magical Shield and projectile strengths are added, this will be changed then.