### PR TITLE
chore: Add linting of imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import tseslint from 'typescript-eslint';
 import stylistic from '@stylistic/eslint-plugin';
 import vueEslintParser from 'vue-eslint-parser';
 import pluginVue from 'eslint-plugin-vue';
+import importPlugin from 'eslint-plugin-import';
 
 export default [
     js.configs.recommended,
@@ -35,6 +36,7 @@ export default [
 
         plugins: {
             '@stylistic': stylistic,
+            'import': importPlugin,
         },
 
         files: [
@@ -84,11 +86,14 @@ export default [
                 "allowNullish": true,
                 "allowNumber": true,
             }],
+            "import/no-default-export": "error",
+            "import/no-duplicates": "error",
+            "import/no-relative-packages": "error",
+            "import/order": "error",
             indent: ["error", 4, {"SwitchCase": 1}],
             "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
             "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
             semi: "off",
-            //"sort-imports": "error",
             "space-before-function-paren": ["error", "never"],
             "vue/html-indent": ["error", 4],
             // Needed for v-data-table "item.colName" renderer slots

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "canvas": "3.2.0",
         "coveralls": "3.1.1",
         "eslint": "9.34.0",
+        "eslint-plugin-import": "2.32.0",
         "eslint-plugin-vue": "10.4.0",
         "jsdom": "26.1.0",
         "rimraf": "6.0.1",
@@ -1758,6 +1759,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.11.0.tgz",
@@ -2002,6 +2010,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2688,6 +2703,111 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -2736,6 +2856,16 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3226,6 +3356,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -3409,6 +3593,19 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -3514,6 +3711,75 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3573,6 +3839,53 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -3689,6 +4002,134 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-vue": {
@@ -4123,6 +4564,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -4131,6 +4593,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4170,6 +4642,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/getpass": {
@@ -4234,6 +4724,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gopd": {
@@ -4318,6 +4825,22 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4581,6 +5104,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
@@ -4627,6 +5170,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
@@ -4654,6 +5231,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4662,6 +5255,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4681,6 +5294,19 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4807,6 +5433,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4820,6 +5462,22 @@
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5075,6 +5733,19 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -5571,6 +6242,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5597,6 +6321,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -5683,6 +6425,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -6030,6 +6779,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6107,6 +6879,27 @@
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -6314,6 +7107,26 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6334,6 +7147,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -6807,6 +7637,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7107,6 +7952,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -7148,6 +8052,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-indent": {
@@ -7207,6 +8121,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -7448,6 +8375,19 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7486,6 +8426,84 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typedoc": {
@@ -7556,6 +8574,25 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -8037,6 +9074,34 @@
         "is-number-object": "^1.1.1",
         "is-string": "^1.1.1",
         "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "canvas": "3.2.0",
     "coveralls": "3.1.1",
     "eslint": "9.34.0",
+    "eslint-plugin-import": "2.32.0",
     "eslint-plugin-vue": "10.4.0",
     "jsdom": "26.1.0",
     "rimraf": "6.0.1",

--- a/src/Actor.test.ts
+++ b/src/Actor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Rectangle, SpriteSheet } from 'gtp';
 import { Actor, ActorData } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
-import { Rectangle, SpriteSheet } from 'gtp';
 import { Map } from '@/Map';
 
 class TestActor extends Actor {

--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -1,9 +1,9 @@
+import { Rectangle } from 'gtp';
 import { Direction } from './Direction';
 import { ENEMY_HITBOX_STYLE, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { ZeldaGame } from './ZeldaGame';
-import { Rectangle } from 'gtp';
 import { Screen } from '@/Screen';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 export const MOVE_AMT = 1;
 

--- a/src/Animation.test.ts
+++ b/src/Animation.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { Animation } from './Animation';
 import { ZeldaGame } from './ZeldaGame';
 import { AnimationListener } from './AnimationListener';
-import { SpriteSheet } from 'gtp';
 
 const mockSpriteSheet = {
     cellW: 8,

--- a/src/Animations.test.ts
+++ b/src/Animations.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AudioSystem } from 'gtp';
 import {
     createEnemyDiesAnimation,
     createLinkDyingAnimation,
@@ -8,7 +9,6 @@ import {
 import { Link } from '@/Link';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Map } from '@/Map';
-import { AudioSystem } from 'gtp';
 import { Octorok } from '@/enemy/Octorok';
 import { Projectile } from '@/Projectile';
 import { Direction } from '@/Direction';

--- a/src/Animations.ts
+++ b/src/Animations.ts
@@ -1,7 +1,6 @@
+import { FadeOutInState, SpriteSheet } from 'gtp';
 import { Animation } from '@/Animation';
 import { ZeldaGame } from '@/ZeldaGame';
-import { SpriteSheet } from 'gtp';
-import FadeOutInState from 'gtp/lib/gtp/FadeOutInState';
 import { TitleState } from '@/TitleState';
 import { AnimationListener } from '@/AnimationListener';
 import { Actor } from '@/Actor';

--- a/src/BaseState.test.ts
+++ b/src/BaseState.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { Keys, SpriteSheet, Utils } from 'gtp';
 import { BaseState } from './BaseState';
 import { ZeldaGame } from './ZeldaGame';
-import { Keys, Utils } from 'gtp';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 
 const mockSpriteSheet = {
     cellW: 8,

--- a/src/BaseState.ts
+++ b/src/BaseState.ts
@@ -1,6 +1,5 @@
+import { InputManager, Keys, SpriteSheet, State, Utils } from 'gtp';
 import { ZeldaGame } from './ZeldaGame';
-import { InputManager, Keys, State, Utils } from 'gtp';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 
 export class BaseState extends State<ZeldaGame> {
     static readonly INPUT_REPEAT_MILLIS: number = 200;

--- a/src/Bomb.test.ts
+++ b/src/Bomb.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Image } from 'gtp';
 import { Bomb } from './Bomb';
 import { Link } from './Link';
 import { Map } from './Map';
 import { ZeldaGame } from './ZeldaGame';
 import { Octorok } from './enemy/Octorok';
-import Image from 'gtp/lib/gtp/Image';
 import { HERO_HITBOX_STYLE } from '@/Constants';
 
 const mockImage = {

--- a/src/Bomb.ts
+++ b/src/Bomb.ts
@@ -1,8 +1,7 @@
+import { Image, Rectangle } from 'gtp';
 import { Actor } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
 import { Link } from './Link';
-import Rectangle from 'gtp/lib/gtp/Rectangle';
-import Image from 'gtp/lib/gtp/Image';
 import { BombSmoke } from '@/BombSmoke';
 import { HERO_HITBOX_STYLE } from '@/Constants';
 

--- a/src/BombSmoke.test.ts
+++ b/src/BombSmoke.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Image } from 'gtp';
 import { HERO_HITBOX_STYLE } from '@/Constants';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Link } from '@/Link';
-import Image from 'gtp/lib/gtp/Image';
 import { BombSmoke } from '@/BombSmoke';
 import { Octorok } from '@/enemy/Octorok';
 import { Direction } from '@/Direction';

--- a/src/BombSmoke.ts
+++ b/src/BombSmoke.ts
@@ -1,7 +1,7 @@
+import { Rectangle, SpriteSheet } from 'gtp';
 import { Actor } from '@/Actor';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Direction } from '@/Direction';
-import { Rectangle, SpriteSheet } from 'gtp';
 import { HERO_HITBOX_STYLE, TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
 
 interface FrameInfo {

--- a/src/CurtainOpeningState.test.ts
+++ b/src/CurtainOpeningState.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { CurtainOpeningState } from './CurtainOpeningState';
 import { MainGameState } from './MainGameState';
 import { ZeldaGame } from './ZeldaGame';
 import { Map } from '@/Map';
-import { SpriteSheet } from 'gtp';
 
 const mockSpriteSheet = {
     drawByIndex: vi.fn(),

--- a/src/CurtainOpeningState.ts
+++ b/src/CurtainOpeningState.ts
@@ -1,6 +1,6 @@
+import { Delay, State } from 'gtp';
 import { HUD_HEIGHT, SCREEN_HEIGHT, SCREEN_WIDTH, TILE_WIDTH } from './Constants';
 import { ZeldaGame } from './ZeldaGame';
-import { Delay, State } from 'gtp';
 import { MainGameState } from './MainGameState';
 
 export class CurtainOpeningState extends State<ZeldaGame> {

--- a/src/EnemyGroup.test.ts
+++ b/src/EnemyGroup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EnemyGroup, EnemyInfo } from './EnemyGroup';
 
 describe('EnemyGroup', () => {

--- a/src/Hud.test.ts
+++ b/src/Hud.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Image } from 'gtp';
 import { Hud } from './Hud';
 import { Link } from './Link';
 import { Map } from './Map';
 import { ZeldaGame } from './ZeldaGame';
-import { Image } from 'gtp';
 
 const mockImage = {
     draw: vi.fn(),

--- a/src/Hud.ts
+++ b/src/Hud.ts
@@ -1,5 +1,5 @@
+import { Image } from 'gtp';
 import { ZeldaGame } from './ZeldaGame';
-import Image from 'gtp/lib/gtp/Image';
 import { Link } from './Link';
 
 export class Hud {

--- a/src/InventorySlideState.ts
+++ b/src/InventorySlideState.ts
@@ -1,6 +1,6 @@
+import { Delay, State } from 'gtp';
 import { SCREEN_HEIGHT } from './Constants';
 import { ZeldaGame } from './ZeldaGame';
-import { Delay, State } from 'gtp';
 import { BaseState } from '@/BaseState';
 
 export class InventorySlideState extends State<ZeldaGame> {

--- a/src/InventoryState.test.ts
+++ b/src/InventoryState.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { Image } from 'gtp';
 import { InventoryState } from './InventoryState';
 import { ZeldaGame } from './ZeldaGame';
-import { Image } from 'gtp';
 import { Link } from '@/Link';
 import { Map } from '@/Map';
 

--- a/src/InventoryState.ts
+++ b/src/InventoryState.ts
@@ -1,6 +1,6 @@
+import { InputManager } from 'gtp';
 import { BaseState } from './BaseState';
 import { MainGameState } from './MainGameState';
-import { InputManager } from 'gtp';
 import { InventorySlideState } from '@/InventorySlideState';
 import { CANVAS_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH } from '@/Constants';
 

--- a/src/Link.test.ts
+++ b/src/Link.test.ts
@@ -1,9 +1,9 @@
-import { MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AudioSystem, InputManager, Keys, SpriteSheet } from 'gtp';
 import { Link } from './Link';
 import { Map } from '@/Map';
 import { Octorok } from '@/enemy/Octorok';
 import { ZeldaGame } from '@/ZeldaGame';
-import { AudioSystem, InputManager, Keys, SpriteSheet } from 'gtp';
 import { Projectile } from '@/Projectile';
 import { opposite } from '@/Direction';
 import { AnimationListener } from '@/AnimationListener';

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -1,3 +1,4 @@
+import { InputManager, Keys, Rectangle, SpriteSheet } from 'gtp';
 import { Character } from './Character';
 import { Actor, MOVE_AMT } from './Actor';
 import { Animation } from './Animation';
@@ -8,15 +9,14 @@ import { HERO_HITBOX_STYLE, SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TIL
 import { Sword } from './Sword';
 import { MainGameState } from './MainGameState';
 import { ZeldaGame } from './ZeldaGame';
-import { InputManager, Keys, Rectangle, SpriteSheet } from 'gtp';
 import { Projectile } from './Projectile';
 import { Bomb } from './Bomb';
 import {
-    alwaysSwordThrowingStrategy,
     LinkSwordThrowingStrategy,
+    SwordThrowingStrategyName,
+    alwaysSwordThrowingStrategy,
     maxHeartsSwordThrowingStrategy,
     swordThrowingStrategyForName,
-    SwordThrowingStrategyName,
 } from '@/LinkSwordThrowingStrategy';
 import {
     createLinkDyingAnimation,

--- a/src/LoadingState.test.ts
+++ b/src/LoadingState.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { FadeOutInState, SpriteSheet, Utils } from 'gtp';
 import { CurtainOpeningState } from './CurtainOpeningState';
 import { LoadingState } from './LoadingState';
 import { ZeldaGame } from './ZeldaGame';
-import { FadeOutInState, Utils } from 'gtp';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 
 const mockSpriteSheet: SpriteSheet = {
     gtpImage: {

--- a/src/LoadingState.ts
+++ b/src/LoadingState.ts
@@ -1,9 +1,8 @@
+import { FadeOutInState, Game, ImageAtlasInfo, SpriteSheet, Utils } from 'gtp';
 import { CurtainOpeningState } from './CurtainOpeningState';
 import { MainGameState } from './MainGameState';
 import { TitleState } from './TitleState';
 import { BaseState } from './BaseState';
-import { FadeOutInState, Game, SpriteSheet, Utils } from 'gtp';
-import { ImageAtlasInfo } from 'gtp/lib/gtp/ImageAtlas';
 import { createRecoloredSpriteSheet } from '@/Utils';
 
 /**

--- a/src/MainGameState.test.ts
+++ b/src/MainGameState.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { Image, Keys, SpriteSheet } from 'gtp';
 import { MainGameState } from './MainGameState';
 import { ChangeScreenWarpEvent } from './event/ChangeScreenWarpEvent';
 import { Link } from './Link';
 import { Map } from './Map';
 import { Screen } from './Screen';
 import { ZeldaGame } from './ZeldaGame';
-import { Image, Keys, SpriteSheet } from 'gtp';
 
 const mockImage = {
     draw: vi.fn(),

--- a/src/MainGameState.ts
+++ b/src/MainGameState.ts
@@ -1,3 +1,4 @@
+import { Keys } from 'gtp';
 import { Direction, isHorizontal, isVertical } from './Direction';
 import { HUD_HEIGHT, SCREEN_HEIGHT, SCREEN_WIDTH, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { BaseState } from './BaseState';
@@ -8,7 +9,6 @@ import { ChangeScreenWarpEvent } from './event/ChangeScreenWarpEvent';
 import { Event, EventData } from './event/Event';
 import { InventoryState } from '@/InventoryState';
 import { InventorySlideState } from '@/InventorySlideState';
-import { Keys } from 'gtp';
 
 const SCREEN_SLIDING_INC = 4;
 

--- a/src/Map.test.ts
+++ b/src/Map.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Map, MAP_HEADER, MapData } from './Map';
+import { SpriteSheet } from 'gtp';
+import { MAP_HEADER, Map, MapData } from './Map';
 import { ZeldaGame } from './ZeldaGame';
 import { createMapData } from '@/test-utils';
-import { SpriteSheet } from 'gtp';
 import { WALKABILITY_OVERWORLD } from '@/Constants';
 
 const mockSpriteSheet = {

--- a/src/Projectile.test.ts
+++ b/src/Projectile.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { Link } from './Link';
 import { AnimationProjectileRenderInfo, GoingOffScreenBehavior, Projectile } from './Projectile';
-import { SpriteSheet } from 'gtp';
 import { ZeldaGame } from './ZeldaGame';
 import { Octorok } from '@/enemy/Octorok';
 import { Animation } from '@/Animation';

--- a/src/Projectile.ts
+++ b/src/Projectile.ts
@@ -1,8 +1,8 @@
+import { Rectangle, SpriteSheet } from 'gtp';
 import { HERO_HITBOX_STYLE, SCREEN_HEIGHT, SCREEN_WIDTH, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { Direction } from './Direction';
 import { Actor } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
-import { Rectangle, SpriteSheet } from 'gtp';
 import { Link } from './Link';
 import { SpriteSheetSpriteLocation } from '@/SpriteSheetSpriteLocation';
 import { Animation } from '@/Animation';

--- a/src/RowColumnPair.ts
+++ b/src/RowColumnPair.ts
@@ -1,4 +1,4 @@
-export default interface RowColumnPair {
+export interface RowColumnPair {
     row: number;
     col: number;
 }

--- a/src/RupeeIncrementor.test.ts
+++ b/src/RupeeIncrementor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AudioSystem } from 'gtp';
 import { RupeeIncrementor } from '@/RupeeIncrementor';
 import { ZeldaGame } from '@/ZeldaGame';
-import { AudioSystem } from 'gtp';
 import { Link } from '@/Link';
 
 describe('RupeeIncrementor', () => {

--- a/src/Screen.test.ts
+++ b/src/Screen.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Rectangle } from 'gtp';
 import { EnemyGroup } from './EnemyGroup';
 import { Link } from './Link';
 import { Map } from './Map';
@@ -8,9 +9,8 @@ import { Tileset } from './Tileset';
 import { ZeldaGame } from './ZeldaGame';
 import { GoDownStairsEvent } from '@/event/GoDownStairsEvent';
 import { SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
-import { Rectangle } from 'gtp';
 import { BombableWallEvent } from '@/event/BombableWallEvent';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 const mockPaintTile = vi.fn();
 const mockTileset = {

--- a/src/Screen.ts
+++ b/src/Screen.ts
@@ -1,3 +1,4 @@
+import { Rectangle } from 'gtp';
 import { Actor, ActorData } from './Actor';
 import { SCREEN_COL_COUNT, SCREEN_ROW_COUNT, TILE_HEIGHT, TILE_WIDTH } from './Constants';
 import { Enemy } from './enemy/Enemy';
@@ -10,8 +11,7 @@ import { Link } from './Link';
 import { Tileset } from './Tileset';
 import { ZeldaGame } from './ZeldaGame';
 import { Sword } from './Sword';
-import loadEvent from './editor/event-loader';
-import { Rectangle } from 'gtp';
+import { loadEvent } from './editor/event-loader';
 import { BombableWallEvent } from '@/event/BombableWallEvent';
 
 export class Screen {

--- a/src/Sword.test.ts
+++ b/src/Sword.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AudioSystem } from 'gtp';
 import { Sword } from './Sword';
 import { Link } from './Link';
 import { Map } from './Map';
 import { ZeldaGame } from './ZeldaGame';
 import { Octorok } from '@/enemy/Octorok';
-import { AudioSystem } from 'gtp';
 import { Screen } from '@/Screen';
 
 const mockDrawByIndex = vi.fn();

--- a/src/Sword.ts
+++ b/src/Sword.ts
@@ -1,8 +1,8 @@
+import { Rectangle, SpriteSheet } from 'gtp';
 import { Link } from './Link';
 import { ordinal } from './Direction';
 import { Actor } from './Actor';
 import { ZeldaGame } from './ZeldaGame';
-import { Rectangle, SpriteSheet } from 'gtp';
 import { AnimationProjectileRenderInfo, Projectile } from '@/Projectile';
 import { Animation } from '@/Animation';
 import { HERO_HITBOX_STYLE } from '@/Constants';

--- a/src/Tileset.test.ts
+++ b/src/Tileset.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { Tileset, TilesetData } from './Tileset';
 import { ZeldaGame } from './ZeldaGame';
-import { SpriteSheet } from 'gtp';
 
 const mockDrawByIndex = vi.fn();
 const mockSpriteSheet = {

--- a/src/Tileset.ts
+++ b/src/Tileset.ts
@@ -1,5 +1,5 @@
-import { ZeldaGame } from './ZeldaGame';
 import { SpriteSheet } from 'gtp';
+import { ZeldaGame } from './ZeldaGame';
 
 /**
  * A set of tiles used by a map.

--- a/src/TitleState.test.ts
+++ b/src/TitleState.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { Image, Keys, SpriteSheet } from 'gtp';
 import { TitleState } from './TitleState';
 import { ZeldaGame } from './ZeldaGame';
-import { Image, Keys, SpriteSheet } from 'gtp';
 
 const mockSpriteSheet = {
     drawByIndex: vi.fn(),

--- a/src/TitleState.ts
+++ b/src/TitleState.ts
@@ -1,8 +1,8 @@
+import { Image, InputManager } from 'gtp';
 import { BaseState } from './BaseState';
 import { CurtainOpeningState } from './CurtainOpeningState';
 import { MainGameState } from './MainGameState';
 import { ZeldaGame } from './ZeldaGame';
-import { Image, InputManager } from 'gtp';
 
 export class TitleState extends BaseState {
     private lastKeypressTime: number;

--- a/src/ZeldaGame.test.ts
+++ b/src/ZeldaGame.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AudioSystem, SpriteSheet } from 'gtp';
 import { ZeldaGame } from './ZeldaGame';
 import { Link } from './Link';
 import { Map } from './Map';
 import { Octorok } from './enemy/Octorok';
 import { Screen } from './Screen';
-import { AudioSystem, SpriteSheet } from 'gtp';
 import { createAnimation, createMapData } from '@/test-utils';
 
 const mockSpriteSheet = {

--- a/src/ZeldaGame.ts
+++ b/src/ZeldaGame.ts
@@ -1,15 +1,15 @@
+import { Game, SpriteSheet } from 'gtp';
+import { GameArgs } from 'gtp/lib/gtp/Game';
 import { Link } from './Link';
 import { Actor } from './Actor';
 import { Animation } from './Animation';
 import { Map } from './Map';
-import { Game, SpriteSheet } from 'gtp';
 import { ItemDropStrategy } from './item/ItemDropStrategy';
-import { GameArgs } from 'gtp/lib/gtp/Game';
 import { RupeeIncrementor } from '@/RupeeIncrementor';
 import { createEnemyDiesAnimation } from '@/Animations';
 import { Enemy } from '@/enemy/Enemy';
 import { Hud } from '@/Hud';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 type MapMap = Record<string, Map>;
 

--- a/src/editor-main.ts
+++ b/src/editor-main.ts
@@ -1,7 +1,7 @@
 import { Component, createApp } from 'vue';
-import vuetify from './editor/vuetify-plugin';
+import { vuetify } from './editor/vuetify-plugin';
 import App from './editor/app.vue';
-import store from './editor/store';
+import { store } from './editor/store';
 import '@/editor/editor.css';
 
 const app = createApp(App as Component)

--- a/src/editor/actionable-panel/actionable-panel.test.ts
+++ b/src/editor/actionable-panel/actionable-panel.test.ts
@@ -3,8 +3,8 @@ import { createVuetify } from 'vuetify/framework';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { render, screen } from '@testing-library/vue';
-import ActionablePanel from '@/editor/actionable-panel/actionable-panel.vue';
 import type { Component } from 'vue';
+import ActionablePanel from '@/editor/actionable-panel/actionable-panel.vue';
 
 const vuetify = createVuetify({
     components,

--- a/src/editor/code-viewer.vue
+++ b/src/editor/code-viewer.vue
@@ -21,10 +21,10 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { MapData } from '@/Map';
 import highlighter from 'jshighlight/lib/highlighter';
 import JsonParser from 'jshighlight/lib/parsers/json-parser';
-import '../../node_modules/jshighlight/src/styles/jshl-default.css';
+import { MapData } from '@/Map';
+import 'jshighlight/src/styles/jshl-default.css';
 import { ZeldaGame } from '@/ZeldaGame';
 
 const props = defineProps<{

--- a/src/editor/enemy-selector.vue
+++ b/src/editor/enemy-selector.vue
@@ -175,8 +175,8 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { EnemyGroup, EnemyInfo } from '@/EnemyGroup';
 import { v4 as uuidv4 } from 'uuid';
+import { EnemyGroup, EnemyInfo } from '@/EnemyGroup';
 import { ZeldaGame } from '@/ZeldaGame';
 
 const props = defineProps<{

--- a/src/editor/event-editor.test.ts
+++ b/src/editor/event-editor.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { RenderResult, render, screen, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import EventEditor from './event-editor.vue';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { Plugin } from 'vue';
 import { UserEvent } from '@testing-library/user-event/index';
+import EventEditor from './event-editor.vue';
 import { Event, EventData } from '@/event/Event';
 
 function createEventMock(id: string, type = 'goDownStairs'): Event<EventData> {

--- a/src/editor/event-generators.ts
+++ b/src/editor/event-generators.ts
@@ -2,7 +2,7 @@ import { Event, EventData } from '@/event/Event';
 import { GoDownStairsEvent } from '@/event/GoDownStairsEvent';
 import { ChangeScreenWarpEvent } from '@/event/ChangeScreenWarpEvent';
 import { BombableWallEvent } from '@/event/BombableWallEvent';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 /**
  * Generates an event of some type.

--- a/src/editor/event-loader.test.ts
+++ b/src/editor/event-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import loadEvent from './event-loader';
+import { loadEvent } from './event-loader';
 import { GoDownStairsEvent } from '@/event/GoDownStairsEvent';
 import { ChangeScreenWarpEvent } from '@/event/ChangeScreenWarpEvent';
 import { EventData } from '@/event/Event';

--- a/src/editor/event-loader.ts
+++ b/src/editor/event-loader.ts
@@ -1,9 +1,9 @@
-import { Event, EventData } from '@/event/Event';
 import {
     BombableWallEventGenerator,
     ChangeScreenWarpEventGenerator,
     GoDownStairsEventGenerator,
 } from './event-generators';
+import { Event, EventData } from '@/event/Event';
 import { GoDownStairsEvent, GoDownStairsEventData } from '@/event/GoDownStairsEvent';
 import { ChangeScreenWarpData, ChangeScreenWarpEvent } from '@/event/ChangeScreenWarpEvent';
 import { BombableWallData, BombableWallEvent } from '@/event/BombableWallEvent';
@@ -53,4 +53,4 @@ const loadEvent = (data: EventData): Event<EventData> => {
     }
 };
 
-export default loadEvent;
+export { loadEvent };

--- a/src/editor/main-content.test.ts
+++ b/src/editor/main-content.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/vue';
-import MainContent from './main-content.vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
+import { SpriteSheet } from 'gtp';
+import MainContent from './main-content.vue';
 import { EnemyGroup } from '@/EnemyGroup';
-import { fireEvent } from '@testing-library/vue';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 import { Map } from '@/Map';
 import { ZeldaGame } from '@/ZeldaGame';
 

--- a/src/editor/map-editor.test.ts
+++ b/src/editor/map-editor.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/vue';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import MapEditor from './map-editor.vue';
 import { createVuetify } from 'vuetify';
+import MapEditor from './map-editor.vue';
 
 const mocks = vi.hoisted(() => {
     const mockCommit = vi.fn();

--- a/src/editor/map-preview.test.ts
+++ b/src/editor/map-preview.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import MapPreview from './map-preview.vue';
 import { createVuetify } from 'vuetify';
+import MapPreview from './map-preview.vue';
 
 const vuetify = createVuetify();
 

--- a/src/editor/nav-bar.test.ts
+++ b/src/editor/nav-bar.test.ts
@@ -4,8 +4,8 @@ import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import type { Component, Plugin } from 'vue';
 import { render, screen } from '@testing-library/vue';
-import NavBar from '@/editor/nav-bar.vue';
 import userEvent, { UserEvent } from '@testing-library/user-event';
+import NavBar from '@/editor/nav-bar.vue';
 
 const mocks = vi.hoisted(() => {
     const mockCommit = vi.fn();

--- a/src/editor/screen-misc.test.ts
+++ b/src/editor/screen-misc.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import ScreenMisc from './screen-misc.vue';
 import { createVuetify } from 'vuetify';
-import { Screen } from '@/Screen';
 import { nextTick } from 'vue';
+import ScreenMisc from './screen-misc.vue';
+import { Screen } from '@/Screen';
 
 const mocks = vi.hoisted(() => {
     const mockCommit = vi.fn();

--- a/src/editor/store.test.ts
+++ b/src/editor/store.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import store from './store';
+import { store } from './store';
 import { Screen } from '@/Screen';
 import { ZeldaGame } from '@/ZeldaGame';
 

--- a/src/editor/store.ts
+++ b/src/editor/store.ts
@@ -2,7 +2,7 @@ import { Store, createStore } from 'vuex';
 import { EditorState } from '@/editor/editor';
 import { ZeldaGame } from '@/ZeldaGame';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from '@/Constants';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 // Initialize the game declared in zelda.ts
 const createGame: () => ZeldaGame = () => {
@@ -59,4 +59,4 @@ const store: Store<EditorState> = createStore({
     modules: {},
 });
 
-export default store;
+export { store };

--- a/src/editor/tile-palette.test.ts
+++ b/src/editor/tile-palette.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RenderResult, render, screen } from '@testing-library/vue';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import TilePalette from './tile-palette.vue';
 import { createVuetify } from 'vuetify';
 import { nextTick } from 'vue';
+import { SpriteSheet } from 'gtp';
+import TilePalette from './tile-palette.vue';
 import { ZeldaGame } from '@/ZeldaGame';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 import { Tileset } from '@/Tileset';
 
 const vuetify = createVuetify();

--- a/src/editor/tile-palette.vue
+++ b/src/editor/tile-palette.vue
@@ -12,8 +12,8 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { SpriteSheet } from 'gtp';
 import { TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
-import SpriteSheet from 'gtp/lib/gtp/SpriteSheet';
 import { Tileset } from '@/Tileset';
 import { ZeldaGame } from '@/ZeldaGame';
 

--- a/src/editor/vuetify-plugin.ts
+++ b/src/editor/vuetify-plugin.ts
@@ -21,4 +21,4 @@ const vuetify = createVuetify({
         },
     },
 })
-export default vuetify;
+export { vuetify };

--- a/src/enemy/AbstractWalkingEnemy.ts
+++ b/src/enemy/AbstractWalkingEnemy.ts
@@ -1,9 +1,9 @@
+import { Rectangle } from 'gtp';
+import { Enemy, EnemyStrength } from './Enemy';
 import { randomDir } from '@/Direction';
 import { SCREEN_HEIGHT, SCREEN_WIDTH } from '@/Constants';
 import { Actor } from '@/Actor';
-import { Enemy, EnemyStrength } from './Enemy';
 import { ZeldaGame } from '@/ZeldaGame';
-import { Rectangle } from 'gtp';
 import { Projectile } from '@/Projectile';
 
 /**

--- a/src/enemy/Enemy.ts
+++ b/src/enemy/Enemy.ts
@@ -1,3 +1,4 @@
+import { SpriteSheet } from 'gtp';
 import { Character } from '@/Character';
 import { Actor } from '@/Actor';
 import { SCREEN_COL_COUNT, SCREEN_ROW_COUNT } from '@/Constants';
@@ -5,7 +6,6 @@ import { ordinal } from '@/Direction';
 import { Sword } from '@/Sword';
 import { Screen } from '@/Screen';
 import { ZeldaGame } from '@/ZeldaGame';
-import { SpriteSheet } from 'gtp';
 import { AbstractItem } from '@/item/AbstractItem';
 import { Projectile } from '@/Projectile';
 import { BombSmoke } from '@/BombSmoke';

--- a/src/enemy/Lynel.test.ts
+++ b/src/enemy/Lynel.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Link } from '@/Link';
-import { Lynel } from './Lynel';
-import { ZeldaGame } from '@/ZeldaGame';
 import { SpriteSheet } from 'gtp';
+import { Lynel } from './Lynel';
+import { Link } from '@/Link';
+import { ZeldaGame } from '@/ZeldaGame';
 import { Map } from '@/Map';
 
 const mockDrawByIndex = vi.fn();

--- a/src/enemy/Lynel.ts
+++ b/src/enemy/Lynel.ts
@@ -1,7 +1,7 @@
 import { AbstractWalkingEnemy } from './AbstractWalkingEnemy';
+import { EnemyStrength } from './Enemy';
 import { Projectile } from '@/Projectile';
 import { ZeldaGame } from '@/ZeldaGame';
-import { EnemyStrength } from './Enemy';
 import { isVertical } from '@/Direction';
 
 const CHANGE_DIR_TIMER_MAX = 120; // 2 seconds

--- a/src/enemy/Moblin.test.ts
+++ b/src/enemy/Moblin.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Link } from '@/Link';
-import { Moblin } from './Moblin';
-import { ZeldaGame } from '@/ZeldaGame';
 import { SpriteSheet } from 'gtp';
+import { Moblin } from './Moblin';
+import { Link } from '@/Link';
+import { ZeldaGame } from '@/ZeldaGame';
 import { Map } from '@/Map';
 
 const mockDrawByIndex = vi.fn();

--- a/src/enemy/Moblin.ts
+++ b/src/enemy/Moblin.ts
@@ -1,7 +1,7 @@
 import { AbstractWalkingEnemy } from './AbstractWalkingEnemy';
+import { EnemyStrength } from './Enemy';
 import { Projectile } from '@/Projectile';
 import { ZeldaGame } from '@/ZeldaGame';
-import { EnemyStrength } from './Enemy';
 import { isVertical } from '@/Direction';
 
 const CHANGE_DIR_TIMER_MAX = 120; // 2 seconds

--- a/src/enemy/Octorok.test.ts
+++ b/src/enemy/Octorok.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
-import { Link } from '@/Link';
-import { Octorok } from './Octorok';
-import { ZeldaGame } from '@/ZeldaGame';
 import { AudioSystem, SpriteSheet } from 'gtp';
+import { Octorok } from './Octorok';
+import { Link } from '@/Link';
+import { ZeldaGame } from '@/ZeldaGame';
 import { Map } from '@/Map';
 import { Sword } from '@/Sword';
 

--- a/src/enemy/Octorok.ts
+++ b/src/enemy/Octorok.ts
@@ -1,7 +1,7 @@
-import { Projectile } from '@/Projectile';
 import { AbstractWalkingEnemy } from './AbstractWalkingEnemy';
-import { ZeldaGame } from '@/ZeldaGame';
 import { EnemyStrength } from './Enemy';
+import { Projectile } from '@/Projectile';
+import { ZeldaGame } from '@/ZeldaGame';
 
 const CHANGE_DIR_TIMER_MAX = 120; // 2 seconds
 

--- a/src/enemy/Tektite.test.ts
+++ b/src/enemy/Tektite.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
+import { Tektite } from './Tektite';
 import { Link } from '@/Link';
 import { Screen } from '@/Screen';
 import { ZeldaGame } from '@/ZeldaGame';
-import { Tektite } from './Tektite';
-import { SpriteSheet } from 'gtp';
 
 const mockDrawByIndex = vi.fn();
 const mockSpriteSheet = {

--- a/src/enemy/Tektite.ts
+++ b/src/enemy/Tektite.ts
@@ -1,8 +1,8 @@
-import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT } from '@/Constants';
+import { Rectangle } from 'gtp';
 import { Enemy, EnemyStrength } from './Enemy';
+import { SCREEN_COL_COUNT, SCREEN_HEIGHT, SCREEN_ROW_COUNT } from '@/Constants';
 import { Screen } from '@/Screen';
 import { ZeldaGame } from '@/ZeldaGame';
-import { Rectangle } from 'gtp';
 
 const TOP_MARGIN_ROWS = 2;
 const MAX_PAUSE_TIME = 60;

--- a/src/event/BombableWallEvent.test.ts
+++ b/src/event/BombableWallEvent.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { BombableWallEvent } from './BombableWallEvent';
 import { ZeldaGame } from '@/ZeldaGame';
 import { MainGameState } from '@/MainGameState';
 import { Link } from '@/Link';
 import { createAnimation } from '@/test-utils';
-import { SpriteSheet } from 'gtp';
 import { EnemyGroup } from '@/EnemyGroup';
 import { Map } from '@/Map';
 import { GoDownStairsEvent } from '@/event/GoDownStairsEvent';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 const mockSpriteSheet = {
     drawByIndex: vi.fn(),

--- a/src/event/BombableWallEvent.ts
+++ b/src/event/BombableWallEvent.ts
@@ -5,7 +5,7 @@ import { MainGameState } from '@/MainGameState';
 import { ZeldaGame } from '@/ZeldaGame';
 import { TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
 import { GoDownStairsEvent } from '@/event/GoDownStairsEvent';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 /**
  * Event that denotes a bombable wall.

--- a/src/event/ChangeScreenWarpEvent.test.ts
+++ b/src/event/ChangeScreenWarpEvent.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'v
 import { ChangeScreenWarpEvent } from './ChangeScreenWarpEvent';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Link } from '@/Link';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 describe('ChangeScreenWarpEvent', () => {
     let game: ZeldaGame;

--- a/src/event/ChangeScreenWarpEvent.ts
+++ b/src/event/ChangeScreenWarpEvent.ts
@@ -2,7 +2,7 @@ import { Event, EventData, EventResult} from './Event';
 import { ZeldaGame } from '@/ZeldaGame';
 import { AnimationListener } from '@/AnimationListener';
 import { Animation } from '@/Animation';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 /**
  * An event that denotes that Link is going to warp when moving to a new screen.<p>

--- a/src/event/Event.ts
+++ b/src/event/Event.ts
@@ -1,6 +1,6 @@
 import { ZeldaGame } from '@/ZeldaGame';
 import { TILE_HEIGHT, TILE_WIDTH } from '@/Constants';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 let count = 0;
 

--- a/src/event/GoDownStairsEvent.test.ts
+++ b/src/event/GoDownStairsEvent.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { SpriteSheet } from 'gtp';
 import { GoDownStairsEvent } from './GoDownStairsEvent';
 import { ZeldaGame } from '@/ZeldaGame';
 import { MainGameState } from '@/MainGameState';
 import { Link } from '@/Link';
 import { createAnimation } from '@/test-utils';
-import { SpriteSheet } from 'gtp';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 const mockSpriteSheet = {
     drawByIndex: vi.fn(),

--- a/src/event/GoDownStairsEvent.ts
+++ b/src/event/GoDownStairsEvent.ts
@@ -1,10 +1,10 @@
+import { Event, EventData, EventResult } from './Event';
 import { Animation } from '@/Animation';
 import { AnimationListener } from '@/AnimationListener';
-import { Event, EventData, EventResult } from './Event';
 import { ZeldaGame } from '@/ZeldaGame';
 import { CurtainOpeningState } from '@/CurtainOpeningState';
 import { MainGameState } from '@/MainGameState';
-import RowColumnPair from '@/RowColumnPair';
+import { RowColumnPair } from '@/RowColumnPair';
 
 /**
  * Occurs when Link steps on a stairwell or doorway on the overworld map.

--- a/src/item/Heart.test.ts
+++ b/src/item/Heart.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AssetLoader, Image } from 'gtp';
 import { Heart } from './Heart';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Link } from '@/Link';
-import { AssetLoader, Image } from 'gtp';
 import { TILE_HEIGHT } from '@/Constants';
 import { Octorok } from '@/enemy/Octorok';
 

--- a/src/item/Heart.ts
+++ b/src/item/Heart.ts
@@ -1,7 +1,6 @@
+import { Image, Rectangle } from 'gtp';
 import { AbstractItem } from './AbstractItem';
 import { Actor } from '@/Actor';
-import Image from 'gtp/lib/gtp/Image';
-import Rectangle from 'gtp/lib/gtp/Rectangle';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Link } from '@/Link';
 

--- a/src/item/ItemDropStrategy.ts
+++ b/src/item/ItemDropStrategy.ts
@@ -1,7 +1,7 @@
-import { Enemy } from '@/enemy/Enemy';
 import { AbstractItem } from './AbstractItem';
 import { Heart } from './Heart';
 import { Rupee } from './Rupee';
+import { Enemy } from '@/enemy/Enemy';
 
 type EnemyClass = 'A' | 'B' | 'C' | 'D' | 'X';
 

--- a/src/item/Rupee.test.ts
+++ b/src/item/Rupee.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AssetLoader, Image } from 'gtp';
 import { Rupee } from './Rupee';
 import { ZeldaGame } from '@/ZeldaGame';
 import { Link } from '@/Link';
-import { AssetLoader, Image } from 'gtp';
 import { Octorok } from '@/enemy/Octorok';
 
 const mockImageDraw = vi.fn();

--- a/src/item/Rupee.ts
+++ b/src/item/Rupee.ts
@@ -1,9 +1,8 @@
+import { Image, Rectangle } from 'gtp';
 import { AbstractItem } from './AbstractItem';
 import { Actor } from '@/Actor';
 import { ZeldaGame } from '@/ZeldaGame';
-import Image from 'gtp/lib/gtp/Image';
 import { Link } from '@/Link';
-import Rectangle from 'gtp/lib/gtp/Rectangle';
 
 export type RupeeDenomination = 'yellow' | 'blue' | 'red';
 

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -2,7 +2,9 @@ declare module '*.vue' {
     import { defineComponent } from "vue";
     /* eslint-disable  @typescript-eslint/naming-convention */
     const Component: ReturnType<typeof defineComponent>;
+    /* eslint-disable import/no-default-export */
     export default Component;
+    /* eslint-enable import/no-default-export */
     /* eslint-enable  @typescript-eslint/naming-convention */
 }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,5 @@
-import { Animation } from '@/Animation';
 import { SpriteSheet } from 'gtp';
+import { Animation } from '@/Animation';
 import { ZeldaGame } from '@/ZeldaGame';
 import { MAP_HEADER, MapData } from '@/Map';
 

--- a/src/zelda.ts
+++ b/src/zelda.ts
@@ -1,10 +1,10 @@
 /*
  * Game bootstrap code.  This can be in an inline <script> tag as well.
  */
+import { CanvasResizer, StretchMode } from 'gtp';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from './Constants';
 import { LoadingState } from './LoadingState';
 import { ZeldaGame } from './ZeldaGame';
-import { CanvasResizer, StretchMode } from 'gtp';
 
 declare global {
     interface Window {


### PR DESCRIPTION
Add `eslint-plugin-import` to enforce linting of import statements, to eliminate possible spurious diffs from imports shifting in the future:

1. Enforce import order
2. Forbid multiple import statements from the same package
3. Forbid `default` exports for uniformity